### PR TITLE
Add shared temporal geometry core

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ point-cloud sequences, and Draco-compressed point-cloud sequences. The matching
 tools convert folders of geometry files into `.o4d` containers, and the players
 provide local desktop playback.
 
-The abstractions described in `open4d/core/README.md`—including
-`MeshSequence`, `PointCloudSequence`, transforms, timestamps, and frame
-metadata—are planned work. Research modules do not yet share a single stable
-Python API.
+`open4d/core` now contains the first shared temporal mesh model: a validated
+NumPy-backed `TriangleMesh`, temporal `Frame`, lazy `Sequence`, and provider
+contract. The existing codecs have not yet migrated to it, and point clouds,
+volumes, transforms, and a stable codec API remain planned work. See
+`docs/sequence-design.md` for the architecture and staged migration plan.
 
 ### Research modules
 

--- a/docs/sequence-design.md
+++ b/docs/sequence-design.md
@@ -1,0 +1,144 @@
+# Shared temporal geometry design
+
+## Purpose
+
+`Sequence` is the central Open4D data abstraction: it gives loaders, processors,
+codecs, metrics, viewers, and integrations one lazy random-access interface
+without requiring them to agree on storage or decoding. The intended long-term
+flow is:
+
+```text
+Loader -> Sequence -> Processor -> Sequence -> Codec -> Sequence -> Viewer
+```
+
+This first version deliberately covers triangle meshes only. It establishes the
+value and provider boundaries before codec APIs are changed.
+
+## Existing representations
+
+The repository currently has no shared frame value. The main paths use these
+representations:
+
+| Path | Geometry and attributes | Time and sequence state | Topology |
+|---|---|---|---|
+| TVMC | OBJ files loaded as Open3D `TriangleMesh`; a Trimesh bridge preserves vertex order and converts vertices, faces, vertex normals, RGB colors, and per-corner UVs. Later stages store `(N, 3)` NumPy displacement text/PLY files against a reference mesh. | `firstIndex`, `lastIndex`, and filename numbering; JSON pipeline configuration carries dataset metadata. No frame timestamps. | Input meshes may differ. Fitted/displacement frames require fixed reference vertex order and connectivity. Draco reordering is corrected explicitly with a nearest-neighbor map. |
+| TSMC | Mostly duplicated Open3D mesh and Trimesh conversion code, plus separate static and dynamic meshes and NumPy displacement arrays. Normals are frequently recomputed; OBJ writes often omit colors, normals, and UVs. | Integer filename ranges and command-line frame counts; no shared metadata or timestamps. | Scene extraction can change topology. The displacement representation is fixed to a subdivided reference mesh with vertex correspondence. |
+| N4MC | A local Torch `Mesh(vertices, faces)` wrapper with face normals, point-cloud-utils vertex/face arrays, TSDF tensors, Trimesh evaluation meshes, and Open3D visualization meshes. Marching cubes returns independent vertex, face, and normal arrays. | Dataset samples are dictionaries with string `frame_id`, tensor `index`, paths, and TSDF statistics. Sequence utilities return parallel lists. No common timestamps. | TSDF marching cubes is changing topology. Legacy displacement/KLT experiments assume a fixed vertex count and correspondence. |
+| Former MeshReduce / 4D reconstruction | Native code uses Open3D tensor `TriangleMesh` plus a separate OpenCV texture in `MeshFrame`. Python fusion returns legacy Open3D meshes inside `MeshResult`, with colors and normals held by Open3D. | Transport structures carry device timestamps, pair numbers, and synchronization metadata separately from mesh values. `MeshResult` carries `source_pair` and build metrics. | TSDF extraction and independent mesh merging produce changing topology and vertex counts. |
+| Players | Mesh player consumes `(vertices, faces, timestamp)` tuples and keeps a separate sorted frame-ID list. Point-cloud players use `(points, colors, timestamp)` tuples. | Playback FPS is supplied by the caller rather than derived from timestamps. | Not declared. |
+| `.o4d` I/O | Mesh reader returns `(float32 vertices, uint32 faces, timestamp)`; point readers return `(float32 points, optional uint8 RGB, timestamp)`. Index entries carry stored frame IDs and timestamps; HEAD JSON carries metadata. | Indexed on-demand decoding, but each reader has its own tuple shape. | The v1 container does not declare topology. |
+
+The largest incompatibilities are `faces` versus `triangles`, Torch versus
+NumPy versus Open3D storage, RGB float versus byte colors, per-vertex versus
+per-corner texture coordinates, integer/string frame IDs, timestamps stored
+outside geometry, and implicit topology assumptions. TVMC and TSMC also carry
+near-duplicate mesh conversion and displacement code.
+
+## Layer boundaries
+
+- **Geometry** is a spatial value. `TriangleMesh` owns no time or codec state.
+- **Frame** associates one geometry with a stored frame index, timestamp, and
+  lightweight metadata.
+- **Provider** owns storage and decoding. Its required contract is only frame
+  count plus random access. Metadata, timestamps, topology declarations, and
+  cleanup are optional capabilities.
+- **Sequence** normalizes indexing, iteration, slicing, timing properties, and
+  topology declarations while remaining lazy.
+- **Codec** should consume or produce sequences through providers. Encoded
+  bitstreams and codec configuration do not belong in `TriangleMesh`.
+- **Operation** transforms frames or sequences and may return a lazy provider
+  that performs work on access.
+
+This separation lets a directory loader, `.o4d` decoder, neural decoder, and
+live capture expose the same API without copying their complete output into
+memory.
+
+## Geometry and mutability
+
+`TriangleMesh` validates floating-point `(N, 3)` positions, integer `(M, 3)`
+triangles, finite values, and triangle bounds. Optional colors are RGB/RGBA
+bytes in `[0, 255]` or floating point in `[0, 1]`; normals are floating-point
+`(N, 3)` arrays. Texture coordinates may be per-vertex `(N, 2)` or per-corner
+`(M, 3, 2)`. Named numeric or boolean attributes must align with vertices,
+triangles, or triangle corners.
+
+The object is structurally immutable, but its NumPy buffers may be shared and
+remain writable. Construction uses `numpy.asarray` and does not copy merely to
+change dtype or ownership. A caller that needs a value snapshot must pass
+copies. The attributes and metadata mappings are shallow read-only snapshots.
+
+## Lazy access and views
+
+Creating a `Sequence` reads only provider declarations. `len`, metadata, and
+topology do not request a frame. Integer indexing requests exactly one provider
+frame. A `SequenceView` stores a Python `range` mapping and does not copy or
+decode frames; nested slices remain lightweight.
+
+`timestamps`, `duration`, and average `fps` are explicit properties. They use a
+provider timestamp table when available. Otherwise requesting them may decode
+frames to obtain timestamps. This cost is never paid automatically during
+construction. Timestamps must be finite and nondecreasing.
+
+## Topology declarations
+
+`TopologyMode` has three values:
+
+- `FIXED`: triangle connectivity is invariant. Constant vertex count and vertex
+  correspondence are therefore true unless a provider makes a more specific
+  declaration.
+- `CHANGING`: connectivity changes. Vertex count and correspondence are not
+  inferred because either can still be constant independently.
+- `UNKNOWN`: the provider cannot make a reliable declaration without scanning
+  or decoding the sequence.
+
+These values are declarations, not results of an automatic sequence-wide
+comparison. `has_constant_topology`, `has_constant_vertex_count`, and
+`has_vertex_correspondence` return `None` when the available declaration is
+insufficient. Expensive verification should be a future explicit operation.
+
+## First integration
+
+`open_o4d_mesh_sequence(path)` wraps the existing `O4DMeshReader`. Opening the
+sequence reads the HEAD and frame index but does not decode geometry. Ordinal
+sequence access maps to the stored frame ID and converts only that reader tuple
+to a core `Frame` and `TriangleMesh`. Existing reader and writer APIs remain
+unchanged. The sequence should be used as a context manager so its file closes
+deterministically.
+
+Open3D remains an external frame operation. An adapter converts
+`frame.geometry` to an Open3D mesh for visualization or processing; Open3D does
+not own sequence timing, lazy decoding, or topology declarations.
+
+## Staged migration
+
+1. **TVMC:** add a lazy numbered-OBJ provider for inputs and decoded outputs.
+   Represent fitted reference meshes as `FIXED` sequences, store displacement
+   arrays as named attributes or provider state, and assert vertex
+   correspondence at the boundary. Keep current CLI and files intact.
+2. **TSMC:** reuse the TVMC directory provider, then expose static and dynamic
+   outputs as separate sequences. Mark pre-reference extraction as `CHANGING`
+   and reference-displacement reconstruction as `FIXED`. Remove duplicated
+   Open3D/Trimesh conversion only after parity tests exist.
+3. **N4MC:** first adapt reconstructed Trimesh/marching-cubes outputs through a
+   provider while leaving TSDF training datasets unchanged. Later define a
+   volume geometry type rather than forcing TSDF tensors into `TriangleMesh`.
+   Declare marching-cubes output `CHANGING`.
+4. **Former MeshReduce / 4D reconstruction:** adapt completed `MeshResult`
+   values at the Python boundary, preserving pair number and synchronization
+   data in frame metadata. A future live/ring-buffer provider can represent an
+   unknown-length stream; the current finite `Sequence` should not pretend to
+   solve streaming.
+
+TVMC is the next recommended migration because it already has ordered mesh
+directories, a configuration-level frame range, and a clear transition from
+changing input topology to fixed-reference displacements. Its directory
+provider can then be reused by TSMC and viewers.
+
+## Non-goals
+
+This version does not define point clouds, volumes, transforms, materials,
+live unknown-length streams, mutation/replacement APIs, processing graphs,
+codec interfaces, caching, prefetching, automatic topology scans, or direct
+Open3D methods. It does not rewrite TVMC, TSMC, N4MC, or former MeshReduce.
+Those capabilities should be added after real providers demonstrate their
+requirements.

--- a/open4d/__init__.py
+++ b/open4d/__init__.py
@@ -1,0 +1,23 @@
+"""Open4D public Python API."""
+
+from .core import (
+    Frame,
+    FrameProvider,
+    MemoryFrameProvider,
+    Sequence,
+    SequenceView,
+    TopologyMode,
+    TriangleMesh,
+)
+from .io.o4d_mesh_io import open_o4d_mesh_sequence
+
+__all__ = [
+    "Frame",
+    "FrameProvider",
+    "MemoryFrameProvider",
+    "Sequence",
+    "SequenceView",
+    "TopologyMode",
+    "TriangleMesh",
+    "open_o4d_mesh_sequence",
+]

--- a/open4d/core/README.md
+++ b/open4d/core/README.md
@@ -1,9 +1,6 @@
 # Core Data Structures
 
-Planned home for fundamental 4D abstractions used across Open4D:
-- MeshSequence
-- PointCloudSequence
-- TransformSequence
-- Frame metadata and timestamps
-
-All algorithms in `modules/` should depend on these abstractions, which are not yet implemented.
+The core package provides NumPy-backed `TriangleMesh`, temporal `Frame`, lazy
+`Sequence`, and `FrameProvider` abstractions. See
+[`docs/sequence-design.md`](../../docs/sequence-design.md) for architecture,
+mutability, topology, and migration guidance.

--- a/open4d/core/__init__.py
+++ b/open4d/core/__init__.py
@@ -1,0 +1,16 @@
+"""Shared temporal geometry abstractions."""
+
+from .frame import Frame
+from .geometry import TriangleMesh
+from .provider import FrameProvider, MemoryFrameProvider, TopologyMode
+from .sequence import Sequence, SequenceView
+
+__all__ = [
+    "Frame",
+    "FrameProvider",
+    "MemoryFrameProvider",
+    "Sequence",
+    "SequenceView",
+    "TopologyMode",
+    "TriangleMesh",
+]

--- a/open4d/core/frame.py
+++ b/open4d/core/frame.py
@@ -1,0 +1,41 @@
+"""Temporal frame values."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from numbers import Real
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .geometry import TriangleMesh
+
+
+@dataclass(frozen=True, eq=False)
+class Frame:
+    """A geometry sample identified by a nonnegative index and timestamp."""
+
+    frame_index: int
+    timestamp: float
+    geometry: TriangleMesh
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.frame_index, int) or isinstance(
+            self.frame_index, bool
+        ):
+            raise TypeError("frame_index must be an integer")
+        if self.frame_index < 0:
+            raise ValueError("frame_index must be nonnegative")
+        if not isinstance(self.timestamp, Real) or isinstance(self.timestamp, bool):
+            raise TypeError("timestamp must be a real number")
+        timestamp = float(self.timestamp)
+        if not math.isfinite(timestamp):
+            raise ValueError("timestamp must be finite")
+        if not isinstance(self.geometry, TriangleMesh):
+            raise TypeError("geometry must be a TriangleMesh")
+        if not isinstance(self.metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+
+        object.__setattr__(self, "timestamp", timestamp)
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))

--- a/open4d/core/geometry.py
+++ b/open4d/core/geometry.py
@@ -1,0 +1,169 @@
+"""NumPy-backed geometry values shared by Open4D pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+_RESERVED_ATTRIBUTES = {
+    "positions",
+    "triangles",
+    "colors",
+    "normals",
+    "texture_coordinates",
+}
+
+
+def _array(value: ArrayLike, name: str) -> NDArray:
+    result = np.asarray(value)
+    if not (np.issubdtype(result.dtype, np.number) or result.dtype == np.bool_):
+        raise TypeError(f"{name} must have a numeric or boolean dtype")
+    return result
+
+
+def _finite(array: NDArray, name: str) -> None:
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+
+
+@dataclass(frozen=True, eq=False)
+class TriangleMesh:
+    """A validated triangle mesh that retains the supplied NumPy storage.
+
+    Instances are structurally immutable: fields and the attribute mapping
+    cannot be replaced. Array buffers are intentionally not made read-only and
+    may be shared with the caller. Mutating such a buffer mutates the mesh.
+    Callers that need value immutability should pass copies.
+    """
+
+    positions: NDArray
+    triangles: NDArray
+    colors: NDArray | None = None
+    normals: NDArray | None = None
+    texture_coordinates: NDArray | None = None
+    attributes: Mapping[str, NDArray] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        positions = _array(self.positions, "positions")
+        if positions.ndim != 2 or positions.shape[1:] != (3,):
+            raise ValueError(
+                f"positions must have shape (N, 3); got {positions.shape}"
+            )
+        if not np.issubdtype(positions.dtype, np.floating):
+            raise TypeError("positions must have a floating-point dtype")
+        _finite(positions, "positions")
+
+        triangles = _array(self.triangles, "triangles")
+        if triangles.ndim != 2 or triangles.shape[1:] != (3,):
+            raise ValueError(
+                f"triangles must have shape (M, 3); got {triangles.shape}"
+            )
+        if not np.issubdtype(triangles.dtype, np.integer) or (
+            triangles.dtype == np.bool_
+        ):
+            raise TypeError("triangles must have an integer dtype")
+        if triangles.size and (
+            np.any(triangles < 0) or np.any(triangles >= len(positions))
+        ):
+            raise ValueError(
+                f"triangle indices must be between 0 and {len(positions) - 1}"
+            )
+
+        colors = self._validate_colors(self.colors, len(positions))
+        normals = self._validate_normals(self.normals, len(positions))
+        texture_coordinates = self._validate_texture_coordinates(
+            self.texture_coordinates, len(positions), len(triangles)
+        )
+        attributes = self._validate_attributes(
+            self.attributes, len(positions), len(triangles)
+        )
+
+        object.__setattr__(self, "positions", positions)
+        object.__setattr__(self, "triangles", triangles)
+        object.__setattr__(self, "colors", colors)
+        object.__setattr__(self, "normals", normals)
+        object.__setattr__(self, "texture_coordinates", texture_coordinates)
+        object.__setattr__(self, "attributes", MappingProxyType(attributes))
+
+    @staticmethod
+    def _validate_colors(value: ArrayLike | None, count: int) -> NDArray | None:
+        if value is None:
+            return None
+        colors = _array(value, "colors")
+        if colors.ndim != 2 or colors.shape[0] != count or colors.shape[1] not in (3, 4):
+            raise ValueError(
+                f"colors must have shape ({count}, 3) or ({count}, 4); "
+                f"got {colors.shape}"
+            )
+        if not (
+            np.issubdtype(colors.dtype, np.integer)
+            or np.issubdtype(colors.dtype, np.floating)
+        ) or colors.dtype == np.bool_:
+            raise TypeError("colors must have an integer or floating-point dtype")
+        _finite(colors, "colors")
+        maximum = 255 if np.issubdtype(colors.dtype, np.integer) else 1.0
+        if np.any(colors < 0) or np.any(colors > maximum):
+            raise ValueError(f"colors must be in the range [0, {maximum}]")
+        return colors
+
+    @staticmethod
+    def _validate_normals(value: ArrayLike | None, count: int) -> NDArray | None:
+        if value is None:
+            return None
+        normals = _array(value, "normals")
+        if normals.shape != (count, 3):
+            raise ValueError(
+                f"normals must have shape ({count}, 3); got {normals.shape}"
+            )
+        if not np.issubdtype(normals.dtype, np.floating):
+            raise TypeError("normals must have a floating-point dtype")
+        _finite(normals, "normals")
+        return normals
+
+    @staticmethod
+    def _validate_texture_coordinates(
+        value: ArrayLike | None, vertex_count: int, triangle_count: int
+    ) -> NDArray | None:
+        if value is None:
+            return None
+        coordinates = _array(value, "texture_coordinates")
+        valid_shapes = ((vertex_count, 2), (triangle_count, 3, 2))
+        if coordinates.shape not in valid_shapes:
+            raise ValueError(
+                "texture_coordinates must be per-vertex with shape "
+                f"({vertex_count}, 2) or per-corner with shape "
+                f"({triangle_count}, 3, 2); got {coordinates.shape}"
+            )
+        if not np.issubdtype(coordinates.dtype, np.floating):
+            raise TypeError(
+                "texture_coordinates must have a floating-point dtype"
+            )
+        _finite(coordinates, "texture_coordinates")
+        return coordinates
+
+    @staticmethod
+    def _validate_attributes(
+        values: Mapping[str, ArrayLike], vertex_count: int, triangle_count: int
+    ) -> dict[str, NDArray]:
+        if not isinstance(values, Mapping):
+            raise TypeError("attributes must be a mapping")
+        result: dict[str, NDArray] = {}
+        allowed_counts = {vertex_count, triangle_count, triangle_count * 3}
+        for name, value in values.items():
+            if not isinstance(name, str) or not name:
+                raise ValueError("attribute names must be non-empty strings")
+            if name in _RESERVED_ATTRIBUTES:
+                raise ValueError(f"{name!r} is a reserved attribute name")
+            attribute = _array(value, f"attribute {name!r}")
+            if attribute.ndim == 0 or attribute.shape[0] not in allowed_counts:
+                raise ValueError(
+                    f"attribute {name!r} must be vertex-, triangle-, or "
+                    "triangle-corner-aligned"
+                )
+            _finite(attribute, f"attribute {name!r}")
+            result[name] = attribute
+        return result

--- a/open4d/core/provider.py
+++ b/open4d/core/provider.py
@@ -1,0 +1,84 @@
+"""Frame provider contracts and in-memory implementation."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence as CollectionSequence
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+from .frame import Frame
+
+
+class TopologyMode(str, Enum):
+    """How triangle connectivity varies over a sequence."""
+
+    FIXED = "fixed"
+    CHANGING = "changing"
+    UNKNOWN = "unknown"
+
+
+@runtime_checkable
+class FrameProvider(Protocol):
+    """Minimum random-access contract used by :class:`Sequence`.
+
+    Providers may additionally expose ``metadata``, ``timestamps``,
+    ``topology``, ``has_constant_vertex_count``,
+    ``has_vertex_correspondence``, and ``close``. Sequence consumes these
+    declarations when present without requiring them from every provider.
+    """
+
+    @property
+    def frame_count(self) -> int:
+        """Number of addressable frames."""
+
+    def get_frame(self, index: int) -> Frame:
+        """Return the frame at a nonnegative ordinal position."""
+
+
+class MemoryFrameProvider:
+    """Expose an existing in-memory frame sequence through FrameProvider."""
+
+    def __init__(
+        self,
+        frames: CollectionSequence[Frame],
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        topology: TopologyMode = TopologyMode.UNKNOWN,
+        has_constant_vertex_count: bool | None = None,
+        has_vertex_correspondence: bool | None = None,
+    ) -> None:
+        if not isinstance(frames, CollectionSequence):
+            raise TypeError("frames must be a sequence")
+        stored_frames = tuple(frames)
+        if any(not isinstance(frame, Frame) for frame in stored_frames):
+            raise TypeError("frames must contain only Frame instances")
+        if not isinstance(topology, TopologyMode):
+            raise TypeError("topology must be a TopologyMode")
+        if metadata is not None and not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        for name, value in (
+            ("has_constant_vertex_count", has_constant_vertex_count),
+            ("has_vertex_correspondence", has_vertex_correspondence),
+        ):
+            if value is not None and not isinstance(value, bool):
+                raise TypeError(f"{name} must be bool or None")
+
+        self._frames = stored_frames
+        self.metadata = MappingProxyType(dict(metadata or {}))
+        self.topology = topology
+        self.has_constant_vertex_count = has_constant_vertex_count
+        self.has_vertex_correspondence = has_vertex_correspondence
+
+    @property
+    def frame_count(self) -> int:
+        return len(self._frames)
+
+    @property
+    def timestamps(self) -> tuple[float, ...]:
+        return tuple(frame.timestamp for frame in self._frames)
+
+    def get_frame(self, index: int) -> Frame:
+        if index < 0 or index >= self.frame_count:
+            raise IndexError("frame index out of range")
+        return self._frames[index]

--- a/open4d/core/sequence.py
+++ b/open4d/core/sequence.py
@@ -1,0 +1,175 @@
+"""Lazy temporal geometry sequences and views."""
+
+from __future__ import annotations
+
+import math
+import operator
+from collections.abc import Iterator
+from types import MappingProxyType
+from typing import Any, Mapping, overload
+
+from .frame import Frame
+from .provider import FrameProvider, TopologyMode
+
+
+class Sequence:
+    """A lazy, random-access temporal geometry sequence."""
+
+    def __init__(self, provider: FrameProvider) -> None:
+        if not isinstance(provider, FrameProvider):
+            raise TypeError("provider must implement FrameProvider")
+        count = provider.frame_count
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError("provider.frame_count must be a nonnegative integer")
+        self._provider = provider
+        self._frame_count = count
+        self._timestamps_cache: tuple[float, ...] | None = None
+
+        metadata = getattr(provider, "metadata", {})
+        if not isinstance(metadata, Mapping):
+            raise TypeError("provider metadata must be a mapping")
+        self._metadata = MappingProxyType(dict(metadata))
+
+        topology = getattr(provider, "topology", TopologyMode.UNKNOWN)
+        if not isinstance(topology, TopologyMode):
+            raise TypeError("provider topology must be a TopologyMode")
+        self._topology = topology
+
+    def __len__(self) -> int:
+        return self._frame_count
+
+    @property
+    def frame_count(self) -> int:
+        return len(self)
+
+    @overload
+    def __getitem__(self, index: int) -> Frame: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> "SequenceView": ...
+
+    def __getitem__(self, index: int | slice) -> Frame | "SequenceView":
+        if isinstance(index, slice):
+            return SequenceView(self, range(len(self))[index])
+        try:
+            ordinal = operator.index(index)
+        except TypeError as exc:
+            raise TypeError("sequence indices must be integers or slices") from exc
+        if ordinal < 0:
+            ordinal += len(self)
+        if ordinal < 0 or ordinal >= len(self):
+            raise IndexError("sequence index out of range")
+        frame = self._provider.get_frame(ordinal)
+        if not isinstance(frame, Frame):
+            raise TypeError("provider.get_frame() must return a Frame")
+        return frame
+
+    def frame(self, index: int) -> Frame:
+        """Return a frame by ordinal position."""
+        return self[index]
+
+    def __iter__(self) -> Iterator[Frame]:
+        for index in range(len(self)):
+            yield self[index]
+
+    @property
+    def metadata(self) -> Mapping[str, Any]:
+        return self._metadata
+
+    @property
+    def timestamps(self) -> tuple[float, ...]:
+        """Return ordered timestamps, decoding frames only if required."""
+        if self._timestamps_cache is None:
+            provided = getattr(self._provider, "timestamps", None)
+            values = provided if provided is not None else (
+                self[index].timestamp for index in range(len(self))
+            )
+            timestamps = tuple(float(value) for value in values)
+            if len(timestamps) != len(self):
+                raise ValueError("provider timestamps length does not match frame_count")
+            if any(not math.isfinite(value) for value in timestamps):
+                raise ValueError("provider timestamps must be finite")
+            if any(a > b for a, b in zip(timestamps, timestamps[1:])):
+                raise ValueError("sequence timestamps must be nondecreasing")
+            self._timestamps_cache = timestamps
+        return self._timestamps_cache
+
+    @property
+    def duration(self) -> float:
+        timestamps = self.timestamps
+        return timestamps[-1] - timestamps[0] if len(timestamps) > 1 else 0.0
+
+    @property
+    def fps(self) -> float | None:
+        duration = self.duration
+        return (len(self) - 1) / duration if len(self) > 1 and duration > 0 else None
+
+    @property
+    def topology(self) -> TopologyMode:
+        return self._topology
+
+    @property
+    def has_constant_topology(self) -> bool | None:
+        if self.topology is TopologyMode.FIXED:
+            return True
+        if self.topology is TopologyMode.CHANGING:
+            return False
+        return None
+
+    def _optional_provider_flag(self, name: str) -> bool | None:
+        value = getattr(self._provider, name, None)
+        if value is not None and not isinstance(value, bool):
+            raise TypeError(f"provider {name} must be bool or None")
+        if value is None and self.topology is TopologyMode.FIXED:
+            return True
+        return value
+
+    @property
+    def has_constant_vertex_count(self) -> bool | None:
+        return self._optional_provider_flag("has_constant_vertex_count")
+
+    @property
+    def has_vertex_correspondence(self) -> bool | None:
+        return self._optional_provider_flag("has_vertex_correspondence")
+
+    def close(self) -> None:
+        """Close provider resources when the provider supports it."""
+        close = getattr(self._provider, "close", None)
+        if close is not None:
+            close()
+
+    def __enter__(self) -> "Sequence":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+
+class _ViewProvider:
+    def __init__(self, parent: Sequence, indices: range) -> None:
+        self.parent = parent
+        self.indices = indices
+        self.metadata = parent.metadata
+        self.topology = parent.topology
+        self.has_constant_vertex_count = parent.has_constant_vertex_count
+        self.has_vertex_correspondence = parent.has_vertex_correspondence
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.indices)
+
+    @property
+    def timestamps(self) -> tuple[float, ...]:
+        return tuple(self.parent[index].timestamp for index in self.indices)
+
+    def get_frame(self, index: int) -> Frame:
+        return self.parent[self.indices[index]]
+
+
+class SequenceView(Sequence):
+    """A lightweight ordinal view into another sequence."""
+
+    def __init__(self, parent: Sequence, indices: range) -> None:
+        self.parent = parent
+        self.indices = indices
+        super().__init__(_ViewProvider(parent, indices))

--- a/open4d/io/README.md
+++ b/open4d/io/README.md
@@ -2,3 +2,15 @@
 
 Readers and writers for static and time-varying geometry:
 PLY, OBJ, GLTF, and Open4D-native formats.
+
+Raw mesh `.o4d` files can also be opened through the shared lazy data model:
+
+```python
+from open4d import open_o4d_mesh_sequence
+
+with open_o4d_mesh_sequence("sequence.o4d") as sequence:
+    frame = sequence.frame(0)
+    vertices = frame.geometry.positions
+```
+
+The existing `O4DMeshReader` tuple API remains available for compatibility.

--- a/open4d/io/__init__.py
+++ b/open4d/io/__init__.py
@@ -1,0 +1,15 @@
+"""Open4D container readers, writers, and sequence adapters."""
+
+from .o4d_mesh_io import (
+    O4DMeshFrameProvider,
+    O4DMeshReader,
+    O4DMeshWriter,
+    open_o4d_mesh_sequence,
+)
+
+__all__ = [
+    "O4DMeshFrameProvider",
+    "O4DMeshReader",
+    "O4DMeshWriter",
+    "open_o4d_mesh_sequence",
+]

--- a/open4d/io/o4d_mesh_io.py
+++ b/open4d/io/o4d_mesh_io.py
@@ -7,6 +7,8 @@ from typing import Dict, List, Optional, Tuple, Iterator
 
 import numpy as np
 
+from open4d.core import Frame, Sequence, TopologyMode, TriangleMesh
+
 # ----------------------------
 # Constants / enums
 # ----------------------------
@@ -341,3 +343,44 @@ class O4DMeshReader:
         """Yields (frame_index, timestamp) for available frames."""
         for e in self.index:
             yield e.frame_index, e.timestamp
+
+
+class O4DMeshFrameProvider:
+    """Lazy core Frame provider backed by the existing v1 mesh reader."""
+
+    topology = TopologyMode.UNKNOWN
+    has_constant_vertex_count = None
+    has_vertex_correspondence = None
+
+    def __init__(self, path: str):
+        self._reader = O4DMeshReader(path)
+        self._reader.open()
+        self._entries = tuple(self._reader.index)
+        self.metadata = dict(self._reader.meta)
+
+    @property
+    def frame_count(self) -> int:
+        return len(self._entries)
+
+    @property
+    def timestamps(self) -> Tuple[float, ...]:
+        return tuple(entry.timestamp for entry in self._entries)
+
+    def get_frame(self, index: int) -> Frame:
+        if index < 0 or index >= self.frame_count:
+            raise IndexError("frame index out of range")
+        entry = self._entries[index]
+        vertices, faces, timestamp = self._reader.get_frame(entry.frame_index)
+        return Frame(
+            frame_index=entry.frame_index,
+            timestamp=timestamp,
+            geometry=TriangleMesh(positions=vertices, triangles=faces),
+        )
+
+    def close(self) -> None:
+        self._reader.close()
+
+
+def open_o4d_mesh_sequence(path: str) -> Sequence:
+    """Open a v1 raw-mesh `.o4d` file as a lazy core Sequence."""
+    return Sequence(O4DMeshFrameProvider(path))

--- a/tests/test_core_sequence.py
+++ b/tests/test_core_sequence.py
@@ -1,0 +1,195 @@
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pytest
+
+from open4d.core import (
+    Frame,
+    MemoryFrameProvider,
+    Sequence,
+    SequenceView,
+    TopologyMode,
+    TriangleMesh,
+)
+
+
+def mesh(offset: float = 0.0) -> TriangleMesh:
+    positions = np.array(
+        [[offset, 0.0, 0.0], [offset + 1.0, 0.0, 0.0], [offset, 1.0, 0.0]],
+        dtype=np.float32,
+    )
+    triangles = np.array([[0, 1, 2]], dtype=np.uint32)
+    return TriangleMesh(positions, triangles)
+
+
+def frames() -> list[Frame]:
+    return [Frame(index, index * 0.5, mesh(index)) for index in range(3)]
+
+
+def test_valid_mesh_preserves_storage_and_attributes() -> None:
+    positions = mesh().positions
+    triangles = np.array([[0, 1, 2]], dtype=np.int64)
+    colors = np.ones((3, 4), dtype=np.float32)
+    normals = np.tile([0.0, 0.0, 1.0], (3, 1)).astype(np.float32)
+    coordinates = np.zeros((1, 3, 2), dtype=np.float32)
+    confidence = np.ones(3, dtype=np.float32)
+
+    value = TriangleMesh(
+        positions,
+        triangles,
+        colors=colors,
+        normals=normals,
+        texture_coordinates=coordinates,
+        attributes={"confidence": confidence},
+    )
+
+    assert value.positions is positions
+    assert value.triangles is triangles
+    assert value.attributes["confidence"] is confidence
+    with pytest.raises(TypeError):
+        value.attributes["other"] = confidence
+    with pytest.raises(FrozenInstanceError):
+        value.positions = positions.copy()
+    positions[0, 0] = 2.0
+    assert value.positions[0, 0] == 2.0
+
+
+@pytest.mark.parametrize(
+    ("positions", "triangles", "error", "message"),
+    [
+        (
+            np.zeros((3, 2), dtype=np.float32),
+            np.zeros((0, 3), dtype=np.int32),
+            ValueError,
+            "positions",
+        ),
+        (
+            np.zeros((3, 3), dtype=np.int32),
+            np.zeros((0, 3), dtype=np.int32),
+            TypeError,
+            "floating-point",
+        ),
+        (np.full((3, 3), np.nan), np.zeros((0, 3), dtype=np.int32), ValueError, "finite"),
+        (np.zeros((3, 3)), np.zeros((1, 2), dtype=np.int32), ValueError, "triangles"),
+        (np.zeros((3, 3)), np.zeros((1, 3), dtype=np.float32), TypeError, "integer"),
+    ],
+)
+def test_invalid_mesh_arrays(
+    positions: np.ndarray,
+    triangles: np.ndarray,
+    error: type[Exception],
+    message: str,
+) -> None:
+    with pytest.raises(error, match=message):
+        TriangleMesh(positions, triangles)
+
+
+def test_out_of_range_triangle_indices() -> None:
+    with pytest.raises(ValueError, match="between 0 and 2"):
+        TriangleMesh(np.zeros((3, 3)), np.array([[0, 1, 3]]))
+    with pytest.raises(ValueError, match="between 0 and 2"):
+        TriangleMesh(np.zeros((3, 3)), np.array([[0, -1, 2]]))
+
+
+def test_optional_mesh_attribute_validation() -> None:
+    with pytest.raises(ValueError, match="colors"):
+        TriangleMesh(mesh().positions, mesh().triangles, colors=np.ones((2, 3)))
+    with pytest.raises(TypeError, match="normals"):
+        TriangleMesh(
+            mesh().positions,
+            mesh().triangles,
+            normals=np.ones((3, 3), dtype=np.int32),
+        )
+    with pytest.raises(ValueError, match="reserved"):
+        TriangleMesh(
+            mesh().positions,
+            mesh().triangles,
+            attributes={"positions": np.ones(3)},
+        )
+
+
+def test_frame_validation_and_metadata() -> None:
+    value = Frame(4, 1.25, mesh(), metadata={"camera": "left"})
+    assert value.frame_index == 4
+    assert value.timestamp == 1.25
+    assert value.metadata == {"camera": "left"}
+    with pytest.raises(TypeError):
+        value.metadata["camera"] = "right"
+    with pytest.raises(ValueError, match="nonnegative"):
+        Frame(-1, 0.0, mesh())
+    with pytest.raises(ValueError, match="finite"):
+        Frame(0, float("inf"), mesh())
+
+
+class CountingProvider:
+    def __init__(self) -> None:
+        self.values = frames()
+        self.calls: list[int] = []
+        self.metadata = {"dataset": "tiny"}
+        self.topology = TopologyMode.CHANGING
+        self.timestamps = (0.0, 0.5, 1.0)
+        self.has_constant_vertex_count = True
+        self.has_vertex_correspondence = False
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.values)
+
+    def get_frame(self, index: int) -> Frame:
+        self.calls.append(index)
+        return self.values[index]
+
+
+def test_sequence_is_lazy_and_supports_indexing() -> None:
+    provider = CountingProvider()
+    sequence = Sequence(provider)
+
+    assert provider.calls == []
+    assert len(sequence) == sequence.frame_count == 3
+    assert sequence.metadata == {"dataset": "tiny"}
+    assert sequence.timestamps == (0.0, 0.5, 1.0)
+    assert sequence.duration == 1.0
+    assert sequence.fps == 2.0
+    assert provider.calls == []
+
+    assert sequence[1].frame_index == 1
+    assert sequence[-1].frame_index == 2
+    assert sequence.frame(0).frame_index == 0
+    assert provider.calls == [1, 2, 0]
+    with pytest.raises(IndexError):
+        _ = sequence[3]
+    with pytest.raises(IndexError):
+        _ = sequence[-4]
+
+
+def test_sequence_slicing_is_lazy_and_composable() -> None:
+    provider = CountingProvider()
+    sequence = Sequence(provider)
+
+    view = sequence[::2]
+    nested = view[::-1]
+
+    assert isinstance(view, SequenceView)
+    assert len(view) == 2
+    assert len(nested) == 2
+    assert provider.calls == []
+    assert nested[0].frame_index == 2
+    assert provider.calls == [2]
+
+
+def test_iteration_and_topology_declarations() -> None:
+    provider = CountingProvider()
+    sequence = Sequence(provider)
+
+    assert [frame.frame_index for frame in sequence] == [0, 1, 2]
+    assert sequence.topology is TopologyMode.CHANGING
+    assert sequence.has_constant_topology is False
+    assert sequence.has_constant_vertex_count is True
+    assert sequence.has_vertex_correspondence is False
+
+    fixed = Sequence(
+        MemoryFrameProvider(frames(), topology=TopologyMode.FIXED)
+    )
+    assert fixed.has_constant_topology is True
+    assert fixed.has_constant_vertex_count is True
+    assert fixed.has_vertex_correspondence is True

--- a/tests/test_o4d_mesh_sequence.py
+++ b/tests/test_o4d_mesh_sequence.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from open4d import TopologyMode, open_o4d_mesh_sequence
+from open4d.io.o4d_mesh_io import O4DMeshReader, O4DMeshWriter
+
+
+def test_o4d_mesh_sequence_decodes_frames_lazily(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "tiny.o4d"
+    positions = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        dtype=np.float32,
+    )
+    triangles = np.array([[0, 1, 2]], dtype=np.uint32)
+    with O4DMeshWriter(str(path), meta={"dataset": "tiny"}) as writer:
+        writer.write_keyframe(positions, triangles, frame_index=4, timestamp=1.0)
+        writer.write_keyframe(
+            positions + 1.0, triangles, frame_index=8, timestamp=1.5
+        )
+
+    calls = []
+    original = O4DMeshReader.get_frame
+
+    def counted_get_frame(self, frame_index):
+        calls.append(frame_index)
+        return original(self, frame_index)
+
+    monkeypatch.setattr(O4DMeshReader, "get_frame", counted_get_frame)
+
+    with open_o4d_mesh_sequence(str(path)) as sequence:
+        assert len(sequence) == 2
+        assert sequence.timestamps == (1.0, 1.5)
+        assert sequence.metadata == {"dataset": "tiny"}
+        assert sequence.topology is TopologyMode.UNKNOWN
+        assert calls == []
+
+        frame = sequence[1]
+        assert frame.frame_index == 8
+        np.testing.assert_array_equal(frame.geometry.positions, positions + 1.0)
+        np.testing.assert_array_equal(frame.geometry.triangles, triangles)
+        assert calls == [8]


### PR DESCRIPTION
## Summary
- add validated NumPy-backed TriangleMesh and temporal Frame values
- add FrameProvider, MemoryFrameProvider, lazy Sequence, and SequenceView
- declare fixed, changing, and unknown topology without eager scans
- expose the existing raw-mesh .o4d reader through a lazy Sequence adapter
- document current representation incompatibilities and a future staged migration plan

## Scope
This PR does not migrate or modify TVMC, TSMC, N4MC, MeshReduce, or any files under open4d/modules. Existing codec and O4D reader APIs remain compatible.

## Testing
- python3 -B -m pytest -q tests: 13 passed
- git diff --check

## Notes
Three locally modified tracked bytecode files were deliberately excluded from the commit.