### PR TITLE
Add complete MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,21 @@
 MIT License
 
-Copyright (c) SINRG Lab
+Copyright (c) 2026 SINRG Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -252,3 +252,8 @@ alongside the code that consumes it.
 
 Please contact the Open4D maintainers before adding a large dataset, checkpoint,
 or third-party source tree.
+
+## License
+
+Open4D is distributed under the [MIT License](LICENSE). Bundled third-party
+components and submodules remain subject to their respective license terms.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "open4d"
 version = "0.1.0"
 requires-python = ">=3.10"
+license = { file = "LICENSE" }
 dependencies = ["numpy"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- replace the incomplete root license stub with the full MIT license terms
- retain the existing SINRG Lab attribution and add the 2026 copyright year
- declare the license file in Python package metadata
- document that bundled third-party components retain their own licenses

## Validation
- parsed `pyproject.toml` successfully
- `git diff --check` passed