### PR TITLE
Establish P0 release safety foundation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,56 +1,10 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# Keep the installed CodeRabbit app inactive for this repository. CodeRabbit is
+# a review bot, not a GitHub Actions runner; CI is defined only in .github/workflows.
 language: en-US
-early_access: false
 
 reviews:
-  profile: assertive
-  request_changes_workflow: true
-  high_level_summary: true
-  poem: false
-  review_status: true
   auto_review:
-    enabled: true
-    drafts: false
-    base_branches:
-      - main
-  path_filters:
-    - "!**/*.lock"
-    - "!**/*.zip"
-    - "!**/*.pdf"
-    - "!**/*.pt"
-    - "!**/*.pth"
-    - "!**/*.so"
-    - "!**/*.dylib"
-    - "!build/**"
-    - "!dist/**"
-    - "!open4d/codecs/**/data/**"
-    - "!open4d/codecs/**/outputs/**"
-    - "!open4d/reconstruction/**/data/**"
-    - "!open4d/reconstruction/**/outputs/**"
-  path_instructions:
-    - path: "pyproject.toml"
-      instructions: |
-        Reject automatic package discovery or any change that can include
-        research codecs, reconstruction systems, datasets, or native binaries
-        in the lightweight distribution. The base dependency must stay NumPy-only.
-    - path: "scripts/check_*contents.py"
-      instructions: |
-        Treat missing checks, permissive globs, and unaccounted archive members
-        as release-safety defects. Exact distribution contents must fail closed.
-    - path: "open4d/core/**"
-      instructions: |
-        Preserve canonical dtypes, laziness, finite random access, timestamp
-        validation, topology declarations, cleanup, and error propagation.
-    - path: "docs/**/*.md"
-      instructions: |
-        Flag broken links and claims that do not name evidence, environment, or
-        the distinction between isolated research behavior and Open4D integration.
-    - path: "THIRD_PARTY.md"
-      instructions: |
-        Never infer license clearance. New copied code, data, models, media,
-        binaries, papers, or submodules require immutable provenance and an
-        explicit release decision.
+    enabled: false
 
 chat:
-  auto_reply: true
-  art: false
+  auto_reply: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+early_access: false
+
+reviews:
+  profile: assertive
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_filters:
+    - "!**/*.lock"
+    - "!**/*.zip"
+    - "!**/*.pdf"
+    - "!**/*.pt"
+    - "!**/*.pth"
+    - "!**/*.so"
+    - "!**/*.dylib"
+    - "!build/**"
+    - "!dist/**"
+    - "!open4d/codecs/**/data/**"
+    - "!open4d/codecs/**/outputs/**"
+    - "!open4d/reconstruction/**/data/**"
+    - "!open4d/reconstruction/**/outputs/**"
+  path_instructions:
+    - path: "pyproject.toml"
+      instructions: |
+        Reject automatic package discovery or any change that can include
+        research codecs, reconstruction systems, datasets, or native binaries
+        in the lightweight distribution. The base dependency must stay NumPy-only.
+    - path: "scripts/check_*contents.py"
+      instructions: |
+        Treat missing checks, permissive globs, and unaccounted archive members
+        as release-safety defects. Exact distribution contents must fail closed.
+    - path: "open4d/core/**"
+      instructions: |
+        Preserve canonical dtypes, laziness, finite random access, timestamp
+        validation, topology declarations, cleanup, and error propagation.
+    - path: "docs/**/*.md"
+      instructions: |
+        Flag broken links and claims that do not name evidence, environment, or
+        the distinction between isolated research behavior and Open4D integration.
+    - path: "THIRD_PARTY.md"
+      instructions: |
+        Never infer license clearance. New copied code, data, models, media,
+        binaries, papers, or submodules require immutable provenance and an
+        explicit release decision.
+
+chat:
+  auto_reply: true
+  art: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,8 +9,8 @@ reviews:
   poem: false
   review_status: true
   auto_review:
-    enabled: true
-    drafts: true
+    enabled: false
+    drafts: false
     base_branches:
       - main
   path_filters:
@@ -52,5 +52,5 @@ reviews:
         explicit release decision.
 
 chat:
-  auto_reply: true
+  auto_reply: false
   art: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,10 +1,56 @@
-# Keep the installed CodeRabbit app inactive for this repository. CodeRabbit is
-# a review bot, not a GitHub Actions runner; CI is defined only in .github/workflows.
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: en-US
+early_access: false
 
 reviews:
+  profile: assertive
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
   auto_review:
-    enabled: false
+    enabled: true
+    drafts: true
+    base_branches:
+      - main
+  path_filters:
+    - "!**/*.lock"
+    - "!**/*.zip"
+    - "!**/*.pdf"
+    - "!**/*.pt"
+    - "!**/*.pth"
+    - "!**/*.so"
+    - "!**/*.dylib"
+    - "!build/**"
+    - "!dist/**"
+    - "!open4d/codecs/**/data/**"
+    - "!open4d/codecs/**/outputs/**"
+    - "!open4d/reconstruction/**/data/**"
+    - "!open4d/reconstruction/**/outputs/**"
+  path_instructions:
+    - path: "pyproject.toml"
+      instructions: |
+        Reject automatic package discovery or any change that can include
+        research codecs, reconstruction systems, datasets, or native binaries
+        in the lightweight distribution. The base dependency must stay NumPy-only.
+    - path: "scripts/check_*contents.py"
+      instructions: |
+        Treat missing checks, permissive globs, and unaccounted archive members
+        as release-safety defects. Exact distribution contents must fail closed.
+    - path: "open4d/core/**"
+      instructions: |
+        Preserve canonical dtypes, laziness, finite random access, timestamp
+        validation, topology declarations, cleanup, and error propagation.
+    - path: "docs/**/*.md"
+      instructions: |
+        Flag broken links and claims that do not name evidence, environment, or
+        the distinction between isolated research behavior and Open4D integration.
+    - path: "THIRD_PARTY.md"
+      instructions: |
+        Never infer license clearance. New copied code, data, models, media,
+        binaries, papers, or submodules require immutable provenance and an
+        explicit release decision.
 
 chat:
-  auto_reply: false
+  auto_reply: true
+  art: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## What changed
+# What changed
 
 Describe the behavior and repository area changed.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## What changed
+
+Describe the behavior and repository area changed.
+
+## Verification
+
+- Commands and results:
+- Python, OS, GPU/hardware:
+- Input and output fixture/artifact:
+
+## Safety checklist
+
+- [ ] Tests cover success, empty input, and relevant failure paths.
+- [ ] Optional dependencies remain optional and have actionable errors.
+- [ ] Wheel/sdist boundaries are unchanged or their exact checks were updated.
+- [ ] `THIRD_PARTY.md` was updated for copied code, data, models, papers, media, binaries, or submodules.
+- [ ] No credentials, private captures, generated outputs, or local datasets were added.
+- [ ] Documentation and status claims match verified behavior.
+
+## Remaining limitations
+
+State the smallest useful follow-up.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   core:
     name: Core / Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -34,7 +34,7 @@ jobs:
 
   open3d:
     name: Open3D / Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
 
   package:
     name: Exact distribution boundary
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
 
   quality:
     name: Source, documentation, and provenance
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core:
+    name: Core / Python ${{ matrix.python-version }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install lightweight development environment
+        run: python -m pip install -e '.[dev]'
+      - name: Run default headless tests
+        run: python -m pytest
+
+  open3d:
+    name: Open3D / Python ${{ matrix.python-version }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install Open3D test tier
+        run: python -m pip install -e '.[dev,open3d]'
+      - name: Run Open3D adapter tests
+        run: python -m pytest integrations/open3d/tests
+
+  package:
+    name: Exact distribution boundary
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Build source and wheel distributions
+        run: |
+          python -m pip install 'build>=1.2'
+          python -m build
+      - name: Assert exact wheel contents
+        run: python scripts/check_wheel_contents.py "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+      - name: Assert source-distribution contents
+        run: python scripts/check_sdist_contents.py "$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
+      - name: Install wheel in a clean environment
+        run: |
+          python -m venv /tmp/open4d-wheel-smoke
+          /tmp/open4d-wheel-smoke/bin/python -m pip install "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          /tmp/open4d-wheel-smoke/bin/python -m pip check
+          cd /tmp
+          /tmp/open4d-wheel-smoke/bin/python -c "import open4d, integrations; print(open4d.__file__)"
+
+  quality:
+    name: Source, documentation, and provenance
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Compile supported Python sources
+        run: >-
+          python -m compileall -q
+          open4d/__init__.py open4d/core open4d/torch_ops
+          integrations/__init__.py integrations/open3d
+          examples/visualization scripts
+      - name: Check shell syntax
+        run: bash -n scripts/*.sh
+      - name: Check local Markdown links
+        run: python scripts/check_markdown_links.py
+      - name: Check provenance and distribution containment
+        run: |
+          python scripts/check_provenance.py
+          python scripts/check_release_gate.py --expect-blocked
+      - name: Check whitespace errors
+        run: git diff --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   core:
     name: Core / Python ${{ matrix.python-version }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -34,7 +34,7 @@ jobs:
 
   open3d:
     name: Open3D / Python ${{ matrix.python-version }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
 
   package:
     name: Exact distribution boundary
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
 
   quality:
     name: Source, documentation, and provenance
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   provenance:
     name: Require cleared provenance ledger
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   provenance:
     name: Require cleared provenance ledger
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,22 @@
+name: Release gate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  provenance:
+    name: Require cleared provenance ledger
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify containment and release clearance
+        run: |
+          python scripts/check_provenance.py
+          python scripts/check_release_gate.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to Open4D
+
+Open4D combines a lightweight Python package with independent research
+systems. A component is complete only when setup is reproducible, a licensed
+sample runs end to end, automated tests pass, outputs are documented, and the
+component works through its supported Open4D interface.
+
+## Release safety
+
+Do not publish a PyPI package, GitHub release, container, dataset, model,
+native plugin, or repository bundle while `THIRD_PARTY.md` contains unresolved
+`BLOCK` entries. The explicit Python package list is technical containment; it
+is not legal approval to publish.
+
+## Contribution lanes
+
+- **Lightweight platform:** `open4d.core`, `open4d.torch_ops`, the Open3D
+  adapter, examples, documentation, and CPU tests.
+- **Research codecs:** each directory under `open4d/codecs/` is an independent
+  experimental environment. Preserve the paper implementation and integrate
+  through narrow adapters.
+- **RGB-D reconstruction and transport:** hardware, CUDA, and network work
+  under `open4d/reconstruction/rgbd/`. Prefer synthetic or recorded tests.
+- **Gaussian reconstruction:** treat the imported research directories as
+  isolated components and avoid unrelated refactors.
+- **Unity/XR:** experimental native integration with unresolved binary and
+  fixture provenance.
+
+Do not combine unrelated lanes in one pull request or opportunistically clean
+up copied research code.
+
+## Lightweight setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e '.[dev]'
+python -m pytest
+```
+
+The base package supports Python 3.10–3.13. Open3D is tested on 3.10–3.12.
+Optional test tiers are explicit:
+
+```bash
+python -m pip install -e '.[dev,open3d]'
+python -m pytest -m open3d integrations/open3d/tests
+
+python -m pip install -e '.[dev,torch]'
+python -m pytest -m torch open4d/torch_ops/tests
+```
+
+Registered markers are `cpu`, `open3d`, `torch`, `gpu`, `hardware`, and
+`slow`. Tests needing GPUs, physical hardware, local datasets, or graphical
+sessions must not run in the default tier.
+
+## Required checks
+
+Run the checks relevant to your change:
+
+```bash
+python -m pytest
+python -m compileall -q open4d integrations examples/visualization scripts
+bash -n scripts/*.sh
+python scripts/check_markdown_links.py
+python scripts/check_provenance.py
+python scripts/check_release_gate.py --expect-blocked
+python -m build
+python scripts/check_wheel_contents.py dist/open4d-*.whl
+python scripts/check_sdist_contents.py dist/open4d-*.tar.gz
+```
+
+## Public boundary rules
+
+- Keep the base install NumPy-only and import optional dependencies lazily.
+- Preserve `TriangleMesh -> Frame -> FrameProvider -> Sequence` layering and
+  canonical dtype normalization.
+- Do not call a codec artifact self-contained until it decodes in a fresh
+  process without original geometry or undeclared encoder intermediates.
+- Keep finite `Sequence` separate from future live-stream semantics.
+- Report payload, container, filesystem, and wire bytes separately.
+- Do not force point clouds, TSDF volumes, or Gaussian splats into
+  `TriangleMesh`.
+
+## Data and provenance
+
+Follow [`docs/artifacts.md`](docs/artifacts.md). Do not add datasets, training
+runs, checkpoints, decoded geometry, logs, or generated videos. A deliberately
+small fixture needs a known license, provenance, checksum, and a test that
+requires it.
+
+Any copied code, submodule, model, dataset, binary, paper, or media addition
+must update [`THIRD_PARTY.md`](THIRD_PARTY.md) with its immutable source,
+revision, modifications, license, distribution constraints, and release
+decision.
+
+## Pull-request evidence
+
+A pull request must state the behavior changed, commands and environment used,
+input/output formats, compatibility impact, provenance impact, and remaining
+limitations. Documentation status claims must name their commit, audit date,
+environment, and verification command.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,24 @@
+# Keep source distributions within the same lightweight boundary as the wheel.
+include LICENSE
+include README.md
+include CONTRIBUTING.md
+include SECURITY.md
+include THIRD_PARTY.md
+include pyproject.toml
+
+prune open4d/codecs
+prune open4d/reconstruction
+prune integrations/unity
+prune examples
+prune apps
+prune docs
+prune scripts
+prune .github
+prune tests
+
+recursive-exclude open4d/core/tests *
+recursive-exclude open4d/torch_ops/tests *
+recursive-exclude integrations/open3d/tests *
+global-exclude __pycache__
+global-exclude *.py[cod]
+global-exclude .DS_Store

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ research.
 > codecs and domain components contain working pipelines, while the shared 4D
 > data model and a common metrics API are still evolving.
 
+## Contributor handbook
+
+New contributors should start with the
+[Open4D Wiki](https://github.com/open4dfoundation/Open4D/wiki) or the versioned
+[`v0.2-dev` handbook source](docs/handbook/v0.2-dev/README.md). The handbook
+explains 3D/4D representations from first principles, maps every repository
+area, separates verified behavior from research claims, and provides the
+dependency-ordered roadmap.
+
+> **Release safety:** redistribution is currently blocked while the
+> third-party provenance and license audit is incomplete. See
+> [`THIRD_PARTY.md`](THIRD_PARTY.md).
+
 <p align="center">
   <img src="docs/assets/open4d-ecosystem.png" width="90%" alt="Open4D ecosystem">
 </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security policy
+
+Open4D is active research software and has not published a supported stable
+release. It includes experimental network receivers, native decoders, GPU
+extensions, model-loading paths, and third-party research systems. Do not
+expose them directly to hostile networks or untrusted artifacts.
+
+## Report a vulnerability
+
+Report vulnerabilities privately through the repository's
+[GitHub security advisory form](https://github.com/open4dfoundation/Open4D/security/advisories/new).
+Do not open a public issue for a vulnerability that could put users, devices,
+data, or infrastructure at risk.
+
+Include the affected revision and component, prerequisites, reproduction
+steps, impact, and proposed mitigation. Remove credentials, device serials,
+private data, and identifying capture content.
+
+## Deployment guidance
+
+- Treat geometry, archives, models, checkpoints, and configurations as
+  untrusted input; parse them with resource limits and least privilege.
+- Bind experimental receivers to localhost by default and use SSH tunneling
+  for remote experiments.
+- Isolate native decoders, Unity plugins, CUDA extensions, and copied research
+  code.
+- Fetch external artifacts only through immutable, checksum-verified
+  references.
+- Revoke exposed credentials before removing them from Git history.
+
+The absence of a warning is not a claim that a component is production-ready.

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,0 +1,71 @@
+# Third-party provenance and release ledger
+
+This ledger records known distribution evidence for Open4D. It was initialized
+from the `v0.2-dev` audit of commit `96b8c7b` on 2026-08-13 and checked against
+`origin/main` at `6d5faf3` on 2026-08-14. It is not legal advice.
+
+## Release decision: blocked
+
+**Do not publish the full repository, a PyPI distribution, container, dataset,
+model, native plugin, or GitHub release.** The tree contains non-commercial and
+no-redistribution terms, GPL code, components with no identified license,
+copied upstream source without complete revision records, native binaries,
+datasets, papers, and model checkpoints with unresolved provenance.
+
+The explicit package list in `pyproject.toml`, `MANIFEST.in`, and the archive
+checks under `scripts/` provide technical containment only. They are not
+permission to publish. A release requires every `BLOCK` entry to be resolved,
+all required notices to be assembled, and a recorded maintainer approval.
+
+## Candidate lightweight boundary
+
+| Package | Basis | Candidate decision |
+| --- | --- | --- |
+| `open4d`, `open4d.core` | Project-authored, root MIT; NumPy base | Candidate after final review |
+| `open4d.torch_ops` | Project-authored source; Torch optional and not redistributed | Candidate after final review |
+| `integrations`, `integrations.open3d` | Project-authored adapter source; Open3D optional and not redistributed | Candidate after final review |
+
+Tests, examples, codecs, reconstruction systems, Gaussian implementations,
+datasets, generated artifacts, papers, Unity files, and vendored source are
+excluded from both candidate wheel and source distribution.
+
+## Component ledger
+
+`BLOCK` means no release artifact may include the component until the required
+evidence is resolved. `EXCLUDED` means it is outside the candidate Python
+distribution and still needs separate review before any redistribution.
+
+| Path / component | Immutable source evidence | License evidence | Decision and required action |
+| --- | --- | --- | --- |
+| `open4d/codecs/draco` | Wrapper plus `google/draco` submodule `47238930f698250f474163e1a29d77858aa5c158` | Upstream Apache-2.0 after initialization; wrapper currently relies on root license | `EXCLUDED`; retain upstream notices and record any patches before source/binary distribution |
+| `open4d/codecs/klt` | Local research implementation; upstream revision not recorded | No component license found | `BLOCK`; identify authorship, upstream revision, and distribution terms |
+| `open4d/codecs/n4mc` | Local/copied implementation with tracked generated outputs | No component license; training/checkpoint lineage absent | `BLOCK`; identify source rights and externalize outputs only after recording hashes and data/model rights |
+| `open4d/codecs/qndf` | Copied research code plus `libigl` submodule `e60423e28c86b6aa2a3f6eb0112e8fd881f96777` | Top-level and `ssp_remesh` contain GPL-3.0 text | `BLOCK`; determine a GPL-compatible source strategy and preserve source/notice obligations |
+| `open4d/codecs/qndf_int8` | Derived experiment; exact base revision not recorded | No component license found | `BLOCK`; record derivation, copyright, license, weights, and data lineage |
+| `open4d/codecs/tvmc` | Research pipeline, copied ARAP/editor trees, Draco `47238930f698250f474163e1a29d77858aa5c158` | `LICENSE.md` permits non-commercial internal research and prohibits redistribution | `BLOCK`; obtain written redistribution authority or keep outside every distributed artifact |
+| `open4d/codecs/tsmc` | Research pipeline, copied trees, Draco `47238930f698250f474163e1a29d77858aa5c158`, SAM3 `5dd401d1c5c1d5c3eedff06d41b77af824517619`, tracked datasets/paper | No top-level component license; copied subtrees have separate terms | `BLOCK`; inventory source, patches, paper/media, data rights, SAM3 terms, and notices |
+| `open4d/codecs/vdmc` | MPEG reference submodule `ecffe4212e5e956761c4fa14a17c453ae916b0b1` | Not audited in the uninitialized tree | `BLOCK`; initialize, record license/notices, and review intended source/binary distribution |
+| `open4d/reconstruction/rgbd` | Project reconstruction and protocol experiments | Root MIT is current repository evidence; camera SDK/native dependencies external | `EXCLUDED`; add dependency ledger and prove fixtures contain no private capture data |
+| `open4d/reconstruction/3dgstream` | Imported research tree; consolidated upstream revision/patch list absent | Top-level MIT plus separate SIBR/rasterizer/Gaussian terms | `BLOCK`; record all upstream revisions, patches, subtree licenses, data/model rights, and allowed artifact boundary |
+| `open4d/reconstruction/queen` | Imported research tree including MiDaS, SIBR, and rasterizers | Top-level NVIDIA non-commercial license plus multiple subtree licenses | `BLOCK`; record revisions, patches, all notices, model/data rights, and redistribution limits |
+| `open4d/reconstruction/gs_tools` | Consolidated Gaussian tooling tree containing SIBR viewers, GLM, and three rasterizer imports; one immutable upstream/patch manifest is absent | Component-local SIBR, GLM, and rasterizer license files exist with differing terms | `BLOCK`; inventory exact upstream revisions and patches, preserve every notice, and determine compatible source/binary distribution terms |
+| `integrations/unity` | Project glue, copied Eigen, prebuilt plugins, encoded archive | No integration-wide manifest; Eigen has multiple license files; binaries/data unresolved | `BLOCK`; inventory producers, licenses, build revisions, symbols, and fixture rights |
+| `integrations/unity/TVMCUnity/Unity Files/Plugins` | Prebuilt Android `.so` and macOS `.dylib` | Reproducible build and dependency bill absent | `BLOCK`; exclude until reproduced from reviewed source with notices |
+| `integrations/unity/TVMCUnity/EncodedExample/DanceSequence.zip` | Historical encoded dataset archive | Source dataset license/consent absent | `BLOCK`; identify redistribution permission or replace with a licensed synthetic fixture |
+| `open4d/codecs/n4mc/outputs` | Historical checkpoints, configs, metrics, and reconstructions | Training inputs, authorship, and checkpoint rights absent | `BLOCK`; keep out of releases and externalize only after rights and hashes are recorded |
+| Tracked papers and large media | TVMC/TSMC papers and demonstration media are committed | Publication copyright and redistribution basis not recorded centrally | `BLOCK`; record publisher/author permission or link externally instead of redistributing |
+
+## Required record for new material
+
+Any copied source, submodule, binary, model, dataset, paper, image, archive, or
+generated artifact must add:
+
+- canonical upstream URL and immutable revision or SHA-256;
+- copyright holder and local modifications;
+- exact license path and required notices;
+- source/data/model lineage;
+- inclusion or exclusion from each release artifact; and
+- the decision and evidence that closes any former `BLOCK` state.
+
+Run `python scripts/check_provenance.py` after editing this ledger. Automation
+checks coverage and containment; it cannot determine legal compatibility.

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -1,0 +1,31 @@
+# Open4D contributor handbook
+
+The handbook is versioned because the repository contains both a small shared
+platform and several fast-moving research implementations. A status statement
+is useful only when it names the revision it describes.
+
+## Available snapshots
+
+| Snapshot | Repository revision | Audit date | State |
+| --- | --- | --- | --- |
+| [`v0.2-dev`](v0.2-dev/README.md) | `96b8c7bbb48e2a8d231684639cfc57799ca6666d` | 2026-08-13 | Current development baseline |
+
+Start with the current snapshot's [orientation and learning path](v0.2-dev/README.md).
+Then read its [current implementation status](v0.2-dev/implementation-status.md)
+for the live gap between the audited baseline and the roadmap.
+When `v0.2` is released, this directory should be copied to `v0.2/` and frozen;
+future audits should create a new snapshot rather than rewriting history.
+
+## How to read status claims
+
+The handbook separates three different kinds of evidence:
+
+1. **Recorded verification**: a command was run in the named environment and
+   its result was captured by the audit.
+2. **Source inspection**: the code and documentation contain a capability, but
+   this audit did not reproduce it end to end.
+3. **Upstream/research claim**: a paper or imported project describes a result;
+   Open4D has not necessarily reproduced it.
+
+The exact rubric, evidence, and component register are in
+[`v0.2-dev/status.md`](v0.2-dev/status.md).

--- a/docs/handbook/v0.2-dev/README.md
+++ b/docs/handbook/v0.2-dev/README.md
@@ -1,0 +1,150 @@
+# Open4D contributor handbook: v0.2-dev
+
+Open4D is a research workspace for **time-varying 3D geometry**: capturing or
+reconstructing a scene, representing its frames, compressing it, transporting
+or storing it, decoding it, measuring the result, and playing it back. Here,
+“4D” means three spatial dimensions changing over time. It does not mean that a
+mesh has a mysterious fourth spatial axis.
+
+This snapshot describes commit
+`96b8c7bbb48e2a8d231684639cfc57799ca6666d`, audited on 2026-08-13. The short
+version of the audit is:
+
+- Open4D already has useful research implementations and a sound small core.
+- The common platform is not yet the boundary used by the codecs or
+  reconstruction systems.
+- No major pipeline meets the project's strict definition of complete yet.
+- The fastest path forward is to make one small, reproducible vertical slice,
+  then adapt the other methods to the same boundaries.
+
+That audit remains frozen for reproducibility. The live gap between the
+audited baseline and the roadmap is tracked in
+[current implementation status](implementation-status.md).
+
+> **Complete means:** setup is reproducible, a licensed sample runs end to end,
+> automated tests pass, outputs are documented, and the component works through
+> its supported Open4D interface.
+
+## What you should understand first
+
+Open4D contains several different jobs that are easy to confuse:
+
+```text
+real scene or files
+        |
+        v
+capture / reconstruction  -- makes geometry from camera measurements
+        |
+        v
+representation            -- says what one frame and a sequence mean
+        |
+        v
+compression               -- reduces the bytes needed to store/transmit it
+        |
+        v
+container or transport    -- packages bytes on disk or moves them over a network
+        |
+        v
+decode / playback         -- recovers and displays geometry over time
+        |
+        v
+evaluation                -- measures size, speed, latency, and distortion
+```
+
+A codec is not a network protocol. A USD file is not a codec. A TSDF is not a
+triangle mesh. A Gaussian-splat renderer is not a mesh viewer. The project will
+become coherent by giving these jobs explicit boundaries, not by forcing every
+method into one data structure.
+
+## Current maturity
+
+The strongest verified pieces are the NumPy-backed `TriangleMesh`, `Frame`,
+finite lazy `Sequence`, example loaders/comparison tools/viewers, and the
+Open3D adapter. The recorded audit has 106 passing core/visualization tests and
+5 passing Open3D tests on Python 3.12. The codec and RGB-D trees contain useful
+standalone pipelines, but none consumes and produces the shared `Sequence`
+interface. `apps/` is still a README-only scaffold.
+
+Important cautions before publishing or redistributing anything:
+
+- root packaging metadata says MIT, while discoverable namespace packages and
+  imported source include components with GPL, non-commercial, or
+  no-redistribution terms;
+- the root submodules were uninitialized in the audited checkout;
+- tracked historical datasets, results, binaries, and papers make the checkout
+  about 1.2 GB;
+- Gaussian-splat work is owned by Ryan and is intentionally outside general
+  cleanup or refactoring.
+
+See the historical [component status register](status.md) and then the
+[current implementation status](implementation-status.md) before relying on a
+feature.
+
+## Fast learning path
+
+Read these in order if you want to contribute heavily:
+
+1. [3D/4D primer](primer.md) — the vocabulary and representations.
+2. [System architecture](architecture.md) — how the jobs should connect and how
+   they connect today.
+3. [Repository and feature map](repository-map.md) — where each job lives.
+4. [Core, I/O, USD, and metrics](platform.md) — the shared boundary new work
+   should use.
+5. [Codec guide](codecs.md) — what every compression approach is trying to do.
+6. [Reconstruction and streaming](reconstruction-streaming.md) — cameras,
+   TSDF fusion, transports, Unity, and Gaussian splats.
+7. [Component status](status.md) — evidence at the audited baseline.
+8. [Current implementation status](implementation-status.md) — what exists in
+   the working branch and the ranked remaining work.
+9. [Contributing and reproducibility](contributing.md) — environments, tests,
+   artifacts, review rules, and ownership.
+10. [Dependency-ordered roadmap](roadmap.md) — the prioritized 90-day plan and
+   post-90-day backlog.
+11. [Glossary](glossary.md) — a quick reference while reading code and papers.
+
+## First commands
+
+Clone with submodules if you intend to build codecs; the lightweight core does
+not require them:
+
+```bash
+git clone --recurse-submodules https://github.com/open4dfoundation/Open4D.git
+cd Open4D
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+python -m pytest -q open4d/core/tests examples/visualization/tests
+```
+
+The default interpreter support advertised by the package is Python 3.10–3.13.
+The shared codec environment is Python 3.12 because Open3D 0.19 has no Python
+3.13 wheel. Install a viewer only when you have a graphical session:
+
+```bash
+python -m pip install -e '.[player]'
+python examples/visualization/visualize_sequence.py path/to/frames --info
+```
+
+Sequence loaders currently live under `examples/visualization`; the proposed
+`open4d.io.open_sequence` public API is roadmap work and is not implemented in
+the audited baseline.
+
+## How to choose a first contribution
+
+Use the [roadmap](roadmap.md), not directory size, to choose work. Good early
+contributions strengthen shared contracts, tests, packaging, provenance, and a
+small Draco vertical slice. Avoid broad refactors inside research trees. In
+particular, do not change `open4d/reconstruction/queen/`,
+`open4d/reconstruction/3dgstream/`, or define a Gaussian representation without
+Ryan's review.
+
+If you only remember one design rule, remember this one:
+
+```text
+finite files/decoders -> FrameProvider -> Sequence -> metrics/viewers/adapters
+live capture          -> future LiveSource -> recording/snapshot -> Sequence
+```
+
+Keeping the finite and live contracts separate prevents timing, buffering, and
+failure semantics from leaking into a simple random-access container.

--- a/docs/handbook/v0.2-dev/architecture.md
+++ b/docs/handbook/v0.2-dev/architecture.md
@@ -1,0 +1,163 @@
+# System architecture
+
+Open4D's long-term value is not any one codec. It is the ability to put unlike
+loaders, reconstructions, codecs, metrics, containers, and viewers behind clear
+boundaries so an experiment is reproducible and comparable.
+
+## The intended offline architecture
+
+```mermaid
+flowchart LR
+    Input["files or finalized capture"] --> Loader["loader / reconstruction replay"]
+    Loader --> InSeq["finite lazy Sequence"]
+    InSeq --> Process["optional processing"]
+    Process --> Encoder["codec encoder"]
+    Encoder --> Artifact["self-contained encoded artifact"]
+    Artifact --> Decoder["fresh-process decoder"]
+    Decoder --> OutSeq["finite lazy Sequence"]
+    InSeq --> Metrics["versioned shared metrics"]
+    OutSeq --> Metrics
+    OutSeq --> Container["OpenUSD interchange"]
+    OutSeq --> View["viewer / Open3D / Unity adapter"]
+    Metrics --> Manifest["run manifest"]
+    Artifact --> Manifest
+```
+
+The important contracts are:
+
+- `TriangleMesh` is spatial data, not a file, frame, codec, or stream.
+- `Frame` adds source identity, time, and lightweight metadata.
+- `FrameProvider` owns storage and decoding.
+- `Sequence` gives finite, lazy, random access and topology declarations.
+- a codec owns encoded artifacts and configuration, and produces a provider;
+- metrics state their algorithm/version and compare through shared values;
+- a run manifest records inputs, configuration, artifacts, environment, timing,
+  and results.
+
+The existing geometry/frame/provider/sequence separation and canonical NumPy
+dtypes should be preserved.
+
+## The actual v0.2-dev architecture
+
+The public core exists, but most useful I/O and measurement code is in examples,
+and every research pipeline uses its own file/tensor/Open3D conventions:
+
+```mermaid
+flowchart TB
+    Files["OBJ / PLY / USD files<br/>VERIFIED-PARTIAL"] --> IO["example loaders<br/>VERIFIED-PARTIAL"]
+    IO --> Core["TriangleMesh -> Frame -> Sequence<br/>VERIFIED-PARTIAL"]
+
+    RGBD["RGB-D capture and TSDF fusion<br/>WORKING-ISOLATED"]
+    RGBD -. "missing finite FrameProvider" .-> Core
+
+    MultiView["multi-view RGB"] --> GS["QUEEN / 3DGStream<br/>OWNER-RYAN"]
+    GS -. "future representation contract" .-> Core
+
+    subgraph Codecs["offline codec research"]
+        Draco["Draco<br/>WORKING-ISOLATED"]
+        KLT["KLT<br/>WORKING-ISOLATED"]
+        N4MC["N4MC<br/>WORKING-ISOLATED"]
+        QNDF["QNDF<br/>WORKING-ISOLATED"]
+        QINT["QNDF-INT8<br/>EXPERIMENT-COMPLETE"]
+        TVMC["TVMC<br/>WORKING-ISOLATED"]
+        TSMC["TSMC<br/>WORKING-ISOLATED"]
+        VDMC["MPEG V-DMC<br/>EXTERNAL-UNVERIFIED"]
+        Boundary["shared codec boundary<br/>NOT IMPLEMENTED"]
+        Draco --> Boundary
+        KLT --> Boundary
+        N4MC --> Boundary
+        QNDF --> Boundary
+        QINT --> Boundary
+        TVMC --> Boundary
+        TSMC --> Boundary
+        VDMC --> Boundary
+    end
+
+    Boundary -. "missing Sequence adapters" .-> Core
+    Core --> Metrics["example comparison metrics<br/>VERIFIED-PARTIAL"]
+    Core --> Viewer["PyQt playback/comparison<br/>VERIFIED-PARTIAL"]
+    Core --> O3D["Open3D adapter<br/>VERIFIED-PARTIAL"]
+    Core --> USD["example OpenUSD container<br/>VERIFIED-PARTIAL"]
+    TVMC --> Unity["Unity playback<br/>WORKING-ISOLATED"]
+    RGBD --> Network["OBP1 / MRD / WebRTC<br/>WORKING-ISOLATED"]
+    Core -. "no vertical slice" .-> Apps["apps/<br/>SCAFFOLD"]
+```
+
+An arrow here means data can conceptually flow, not that a supported Open4D API
+connects the boxes. Dashed arrows name missing integration boundaries.
+
+## Reconstruction, compression, storage, and transport
+
+These stages must remain separable:
+
+| Stage | Question it answers | Typical input | Typical output in this repository |
+| --- | --- | --- | --- |
+| Capture | What did the sensor observe and when? | RGB, depth, calibration | OBP1 paired RGB-D packets or saved captures |
+| Reconstruction | What 3D representation explains those observations? | calibrated images/depth | point cloud, TSDF-derived mesh, or Gaussians |
+| Processing | How should geometry be normalized/tracked/remeshed? | meshes/volumes | aligned mesh, reference mesh, displacement field |
+| Compression | Which information can be stored approximately with fewer bits? | mesh/TSDF/Gaussians | Draco bytes, coefficients, latent/model, deltas |
+| Container | How are frames and metadata packaged on disk? | frames and streams | planned OpenUSD schema v1 |
+| Transport | How do bounded messages move between peers? | encoded/raw payloads | OBP1, MRD1/2/3 experiments |
+| Playback | How does a consumer schedule and display results? | decoded frames | PyQt/OpenGL, Open3D WebRTC, Unity |
+| Evaluation | What size, quality, speed, and latency were achieved? | reference/output/manifests | JSON, CSV, tables, rendered comparisons |
+
+Keeping these separate lets a new transport carry an old codec, or a new codec
+reuse the same metrics, without copying an entire application.
+
+## Finite sequences versus live streams
+
+`Sequence` is intentionally finite and random-access. A live camera stream has
+unknown length, backpressure, disconnects, frame replacement, clock domains,
+and closure. Pretending it is a `Sequence` makes those semantics implicit.
+
+The future live boundary should look conceptually like:
+
+```text
+LiveSource[Geometry]
+  -> StreamSample(session, epoch, frame_id, presentation_time,
+                  clock, dependency, payload/content type, statistics)
+  -> bounded consumer queues
+  -> recording or frozen snapshot
+  -> finite FrameProvider
+  -> Sequence
+```
+
+The contract must name buffer/drop policy, keyframe dependencies, closure and
+errors, and conversion to a finalized recording. P3 specifies and tests this
+contract; it does not promise production networking.
+
+## Data ownership
+
+Use this placement rule:
+
+- stable NumPy value and finite sequence semantics belong in `open4d.core`;
+- supported general loaders/containers belong in future `open4d.io`;
+- supported general measurements belong in future `open4d.metrics`;
+- heavy or restrictive research implementations remain isolated;
+- external ecosystem conversion belongs in `integrations/`;
+- end-to-end demonstrations belong in `apps/`;
+- runnable teaching and inspection tools belong in `examples/`.
+
+Do not put codec bitstreams in `TriangleMesh.metadata`, make Open3D own sequence
+time, model a TSDF as fake vertices, or model Gaussians as zero-face meshes.
+
+## Roadmap dependency graph
+
+```mermaid
+flowchart LR
+    P0["P0 truth, packaging, CI, tests"] --> P1["P1 public I/O, metrics, USD, manifest"]
+    P1 --> P2["P2 Draco vertical slice"]
+    P2 --> TVMC["P3 TVMC adapter"]
+    P1 --> Replay["P3 RGB-D finite replay"]
+    P1 --> Live["P3 live-stream contract"]
+    Replay --> Live
+    TVMC --> Fanout["post-90-day codec adapters"]
+    P2 --> Fanout
+    Live --> Prod["production streaming"]
+    P1 --> Repr["PointCloud / transform expansion"]
+    Ryan["Ryan-owned Gaussian handoff"] -. "joint review" .-> Repr
+```
+
+The order is intentional. A codec adapter built before public I/O, artifact,
+metric, and manifest contracts will invent private versions that must be
+replaced later.

--- a/docs/handbook/v0.2-dev/codecs.md
+++ b/docs/handbook/v0.2-dev/codecs.md
@@ -1,0 +1,233 @@
+# Codec guide
+
+A codec should turn a declared input into a self-contained encoded artifact and
+turn that artifact back into a declared output. In Open4D, a complete adapter
+will consume a finite `Sequence`, decode lazily through a provider, use shared
+metrics, and emit a run manifest. None of the current codec trees crosses that
+whole boundary at the audited revision.
+
+## Comparison at a glance
+
+| Codec | Representation it compresses | Time model | Training | Natural strength | Main Open4D gap |
+| --- | --- | --- | --- | --- | --- |
+| Draco | triangle mesh attributes/connectivity | each frame independently in current scripts | none | simple, mature CPU baseline | no sequence artifact/provider/manifest vertical slice |
+| KLT | blocks of a TSDF volume | basis learned from selected frames | linear PCA/SVD | interpretable classical baseline | basis/mean and full decoder state are not one artifact |
+| N4MC | TSDF volume latent plus neural decoder | dataset/sequence training, then per-volume reconstruction | neural | compact learned volumetric representation | incomplete entropy/artifact accounting and no sequence adapter |
+| QNDF | coarse mesh plus implicit displacement field | current workflow trains each mesh/frame | neural | preserves detailed surface from coarse geometry | decode bundle omits required coarse/normalization/model context |
+| QNDF-INT8 | QNDF decoder linear layers | isolated single-model comparison | post-training dynamic quantization | answers an FP32-versus-INT8 question | experiment, not a general temporal codec |
+| TVMC | tracked reference mesh plus per-vertex temporal displacement | group/subsequence with reference | classical tracking/linear compression | explicit temporal correspondence | decoder still depends on encoder-side information; no provider |
+| TSMC | static scene plus tracked dynamic mesh | groups of scene frames | segmentation plus tracking/compression | avoids repeatedly coding static scene | side information/artifact and shared adapter incomplete |
+| MPEG V-DMC | dynamic mesh encoded through the MPEG test model | standard-defined temporal coding | none in the neural sense | standards reference and conformance experiments | submodule uninitialized; no Open4D wrapper/verification |
+
+“Bitrate” comparisons are valid only if they count everything required to
+decode: model weights, basis/mean, reference/coarse mesh, normalization,
+topology, entropy tables, and container overhead when appropriate.
+
+## Draco
+
+Draco is Google's general 3D geometry codec. It quantizes and predicts geometry
+attributes/connectivity and entropy-codes them. Open4D uses it as the least
+complex reference path and as a building block inside other pipelines.
+
+Current standalone flow:
+
+```text
+folder of OBJ frames
+  -> draco_encoder for each frame/quantization setting
+  -> .drc files
+  -> draco_decoder
+  -> decoded OBJ files
+  -> codec-local bitrate, D1/D2 PSNR, depth/color SSIM evaluation
+```
+
+The source is a pinned but audit-time-uninitialized submodule. Setup scripts
+build command-line binaries with CMake. The Python wrapper is useful but is not
+a sequence codec: it has no common artifact schema, stored frame timing, lazy
+decoded provider, run manifest, or fresh-process golden test through Open4D.
+
+Draco is the first vertical slice because it needs no GPU training and already
+has a real encode/decode binary boundary. The complete app must encode a tiny
+licensed sequence, store per-frame identity/time/configuration/hash/size, hide
+the source and intermediates, decode in a fresh process, expose a lazy
+`Sequence`, compare using the shared metric, and emit a manifest. Codec payload
+bytes must be separate from filesystem/container/wire bytes.
+
+## KLT
+
+The Karhunen–Loève Transform is PCA applied as a compression transform. Similar
+TSDF blocks are treated as vectors. SVD learns a mean `mu` and basis `P`; target
+blocks are projected onto the most useful basis vectors, coefficients are
+quantized and packed, then inverse-projected. Marching cubes converts the
+reconstructed TSDF back to a mesh.
+
+```text
+TSDF .npz frames
+  -> overlapping training blocks -> SVD basis + mean
+  -> non-overlapping target blocks -> coefficients
+  -> quantization + zstd/zip size estimate
+  -> inverse transform -> TSDF -> marching-cubes mesh
+```
+
+It is a valuable non-neural baseline and documents operating points, but its
+current run is an experiment script rather than an independently decodable
+artifact. The basis, mean, volume/block metadata, coefficient quantization, and
+packed symbols must be serialized together. A real decoder should take only
+that bundle and expose reconstructed mesh frames. GPU memory can still be a
+constraint because the training-block extractor materializes overlapping
+blocks.
+
+## N4MC
+
+N4MC is the repository's neural TSDF mesh-compression line. A surface is
+converted to a TSDF, an encoder produces a compact latent tensor, quantization
+reduces precision, and a neural decoder reconstructs the field. Marching cubes
+extracts a mesh. The tree contains both legacy experiments and a newer modular
+`data/models/losses/training/evaluation` path with YAML configuration,
+validation, reconstruction, latent packs, and a managed basketball runner.
+
+```text
+mesh -> normalized TSDF (+ optional offsets)
+     -> neural encoder -> quantized latent -> neural decoder
+     -> reconstructed TSDF -> marching cubes -> restored mesh
+```
+
+Useful current features include narrow-band/sign-aware losses, saved latent
+packs, checkpointed training, split-aware evaluation, and restoration to source
+coordinates. However, a checkpoint, latent pack, normalization, model
+configuration, and reconstruction parameters are not yet specified as one
+self-contained codec artifact. The rate path is still an entropy proxy rather
+than a complete interoperable bitstream, and decoder model bytes must count
+toward rate. The SSIM objective and its test/implementation contract also need
+reconciliation.
+
+The first adapter should leave TSDF training datasets alone and expose the
+existing reconstructed marching-cubes meshes as a changing-topology provider.
+A first-class volume type should come later, based on demonstrated needs.
+
+## QNDF
+
+Quantized Neural Displacement Fields starts with SSP preprocessing: simplify a
+mesh to a coarse surface, subdivide it, and project the subdivided vertices to
+the original. A small implicit neural representation learns displacement from
+the coarse/subdivided surface to detailed geometry. Network values can then be
+quantized and entropy-coded.
+
+```text
+OBJ -> normalize -> SSP coarse mesh -> subdivide/project training pair
+    -> train implicit displacement decoder
+    -> quantized model + reconstruction -> restore source coordinates
+```
+
+The repository includes a disconnected-component preprocessing path and a
+resumable basketball runner. Its pinned libigl dependency was uninitialized in
+the audit. QNDF is GPL-3.0 licensed, which is one reason package/release scope
+must be resolved before distribution.
+
+A complete artifact must include the coarse/reference geometry, subdivision
+and sampling contract, normalization transform, architecture/configuration,
+trained/quantized parameters, and any entropy metadata. Today those pieces are
+spread across working directories. The first adapter should report one-frame
+and sequence-run outputs without pretending independently trained frames form a
+temporal codec.
+
+## QNDF-INT8
+
+This sibling is intentionally narrower. It takes an existing SSP mesh pair,
+trains the original QNDF architecture, applies PyTorch dynamic INT8
+quantization to each `Linear` layer, and saves reloadable FP32/INT8 TorchScript
+models, reconstructions, artifact sizes, and quality metrics.
+
+That is a completed experiment question—whether the chosen dynamic INT8
+container changes size/quality and reloads—not a complete QNDF artifact or
+sequence codec. Preserve the isolation and its result manifest. Do not merge it
+into the main QNDF path until an explicit general format requires it.
+
+## TVMC
+
+Time-Varying Mesh Compression is a multi-stage temporal pipeline. It tracks
+volume centers through a sequence, deforms frames into a reference pose,
+extracts a self-contact-free reference mesh, deforms the reference forward,
+computes fine displacements, and compresses trajectories. Draco participates in
+reference geometry handling. Python orchestrates NumPy/Open3D work; .NET
+projects perform tracking/editing.
+
+```text
+numbered OBJ sequence
+  -> volume-center tracking
+  -> reference centers + center transforms
+  -> frames deformed to reference -> reference extraction
+  -> reference deformed to each frame
+  -> vertex displacements -> temporal coefficient/trajectory compression
+  -> reconstructed OBJ sequence + metrics
+```
+
+The setup, sample basketball input, dry-run/resumable stage runner, cached
+intermediates, checked subprocess execution, and optimized CPU evaluation paths
+are valuable and should be preserved. TVMC itself is covered by a Northeastern
+non-commercial, non-transferable, non-sublicensable, no-redistribution license;
+release and contribution rules need explicit review.
+
+TVMC is the first temporal adapter after Draco. It should consume the public
+directory `Sequence`, preserve existing CLI/files/resume behavior, serialize
+the information required to restore displacement-to-vertex correspondence,
+decode without original encoder-side displacement values, and expose a finite
+lazy provider. It must declare changing topology before fitting and fixed
+reference topology/correspondence at the correct later boundary.
+
+## TSMC
+
+Time-varying 4D Scene Mesh Compression extends the reference/deformation idea to
+scenes. SAM3-based segmentation separates static and dynamic geometry so the
+unchanged environment need not be recoded every frame. The dynamic portion is
+volume-tracked, represented with a reference mesh and motion/displacement data,
+compressed, and recombined for evaluation.
+
+```text
+scene mesh sequence + rendered segmentation views
+  -> static/dynamic separation
+  -> dynamic volume-center tracking and reference extraction
+  -> deformation + displacement compression
+  -> reconstructed dynamic + static scene -> evaluation
+```
+
+The imported project contains paper assets, tracked sample data, .NET/C++/Python
+stages, Blender-only conversion, SAM3 integration, and its own Draco copy. It is
+useful standalone research code but not a supported Open4D codec. Required
+entropy-model/side information must be serialized, and decoding must start from
+the declared encoded artifact instead of predecoded arrays. After TVMC's
+directory/reference contracts are proven, TSMC should reuse them rather than
+maintain duplicate mesh/displacement conversion.
+
+The advertised VR decoder is not integrated; the current Unity path is TVMC
+specific.
+
+## MPEG V-DMC
+
+V-DMC is the MPEG video-based dynamic mesh coding reference test model. A test
+model is primarily for standards experiments and conformance, not a polished
+library API. It brings its own encoder, decoder, metrics, formats, build system,
+and tests.
+
+At the audited revision the `open4d/codecs/vdmc` submodule was pinned at
+`ecffe4212e5e956761c4fa14a17c453ae916b0b1` but uninitialized, so no build or
+runtime claim is verified here. Initialize and verify upstream first, including
+the known macOS build work tracked by the project, then add an Open4D wrapper
+that records exact test-model revision/configuration and exposes decoded
+geometry through the shared boundary.
+
+## Cross-codec acceptance contract
+
+Every adapter is done only when it passes the same shape of test:
+
+```text
+licensed tiny fixture
+  -> encode
+  -> retain only declared artifact
+  -> start fresh decoder process
+  -> decoded finite Sequence
+  -> shared versioned comparison
+  -> validated run manifest and exact byte accounting
+```
+
+Codec-local scientific metrics remain useful and should be recorded alongside,
+not substituted for, the cross-codec baseline.

--- a/docs/handbook/v0.2-dev/contributing.md
+++ b/docs/handbook/v0.2-dev/contributing.md
@@ -1,0 +1,195 @@
+# Contributing and reproducibility
+
+Open4D combines a small platform, imported research systems, hardware software,
+and restrictive third-party material. A good contribution is not merely code
+that works on its author's machine; it makes its support boundary and evidence
+clear without destabilizing unrelated research.
+
+## Support tiers
+
+Use these tiers in issues, tests, and reviews:
+
+| Tier | Examples | Expected automation |
+| --- | --- | --- |
+| CPU core | `open4d.core`, base install, built-in OBJ/PLY | Python 3.10–3.13 on every change |
+| CPU optional | OpenUSD, viewer non-GUI logic, Torch CPU | marked jobs with their extras |
+| Open3D | adapter and Open3D-backed operations | Python 3.10–3.12; 3.13 unsupported upstream |
+| Research CPU/toolchain | Draco, TVMC/TSMC stages, .NET/CMake | small golden/dry-run jobs where licensed and practical |
+| GPU | neural codecs, CUDA TSDF, Gaussian methods | dedicated runner/manual matrix with exact CUDA/driver |
+| Hardware/UI | cameras, Quest/Unity, interactive GL/WebRTC | documented manual acceptance until runners exist |
+| External reference | MPEG V-DMC | exact upstream pin/build/test record |
+
+Do not make the NumPy-only package import a heavy optional dependency at module
+import time. Fail when the optional feature is called and show the exact extra
+or setup command.
+
+## Environments
+
+### Lightweight core
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+python -m pytest -q open4d/core/tests examples/visualization/tests
+```
+
+Install extras only for the work you are testing:
+
+```bash
+python -m pip install -e '.[player]'
+python -m pip install -e '.[usd]'
+python -m pip install -e '.[tools]'
+python -m pip install -e '.[open3d]'
+```
+
+### Shared codec Python environment
+
+```bash
+conda env create -f environment.yml
+conda activate open4d
+python -m pip install -e .
+```
+
+This environment is Python 3.12, NumPy 1.26.4, Open3D 0.19, and PyTorch 2.7.0.
+Machine-built GPU extensions are documented in `requirements-gpu.txt`; install
+only those required by your codec. `.NET 10`, CMake, CUDA toolkits, Blender,
+camera SDKs, Unity, and vendor drivers are external toolchains, not things pip
+can make reproducible.
+
+Always record `python --version`, relevant package versions, OS/architecture,
+CPU/GPU, driver/CUDA, compiler/CMake/.NET, and the Open4D commit. “CUDA 12” is
+not precise enough when an extension must match PyTorch's exact CUDA build.
+
+## Test tiers and collection
+
+The intended root markers are:
+
+- `cpu`: base deterministic tests;
+- `open3d`: optional adapter/BVH behavior;
+- `torch`: Torch CPU or GPU-aware behavior;
+- `gpu`: requires a suitable GPU/driver/toolkit;
+- `hardware`: cameras, headset, or other physical device;
+- `slow`: unsuitable for normal per-change feedback.
+
+Until root collection is hardened, invoke known suites explicitly. Several
+research scripts are named `test.py`, `decoder_test.py`, or `model_test.py` but
+perform local-dataset/GPU experiments and must not be collected by default.
+Rename or configure them only after preserving their intended commands.
+
+For a new feature, cover at least:
+
+- normal behavior and the smallest meaningful fixture;
+- empty/one-frame/boundary values;
+- malformed data and actionable errors;
+- lifecycle cleanup and failure propagation;
+- laziness: prove which access decodes which frames;
+- exact round-trip fields or explicit unsupported failures;
+- deterministic results or documented tolerances/seeds.
+
+Codec tests must hide the source and encoder intermediates before fresh-process
+decode. If the decoder still succeeds by reading an undeclared original file,
+the test has not validated a codec artifact.
+
+## Artifact and data rules
+
+Follow the repository's [artifact policy](../../artifacts.md): do not commit
+local datasets, training runs, checkpoints, decoded outputs, logs, or benchmark
+work directories. A committed binary fixture must be small, licensed,
+indispensable, and documented beside its consumer.
+
+Prefer a pinned download with SHA-256:
+
+```bash
+./scripts/fetch_artifact.sh \
+  https://stable.example/open4d/example.tar.zst \
+  0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  open4d/codecs/example/datasets/example.tar.zst
+```
+
+Record origin, revision, license, checksum, size, unpack command, and exact
+consumer. Never replace a tracked historical artifact casually: migrate it to
+durable storage with provenance and a reviewed compatibility plan.
+
+Every publishable experiment should emit the run manifest described in
+[the platform chapter](platform.md#run-manifest-v1). Report encoded payload,
+container/filesystem, and wire size separately. Include all decoder state in
+the encoded accounting.
+
+## License and provenance gate
+
+The root MIT license does not erase component terms. Examples in the audited
+tree include GPL-3.0 QNDF, a TVMC non-commercial/no-redistribution agreement,
+NVIDIA/non-commercial Gaussian code, other third-party licenses, prebuilt
+libraries, imported data, and paper assets.
+
+Before adding or distributing any third-party material:
+
+1. record origin and exact revision;
+2. identify the license file and applicable paths;
+3. record modification/patch history;
+4. identify whether source, binary, model, dataset, paper, and output rights
+   differ;
+5. get maintainer/legal review for compatibility and distribution scope;
+6. keep the material outside the lightweight wheel unless explicitly approved.
+
+No package release should be published until the exact wheel allowlist and the
+TVMC/QNDF/copied-upstream/binary/dataset boundaries are resolved. This handbook
+describes risks; it is not legal advice.
+
+## Ownership and safe boundaries
+
+- Shared platform contributors own core, supported I/O/metrics/container
+  contracts, manifests, packaging, and reusable adapters.
+- Codec owners preserve scientific semantics and approve changes to training,
+  encoded formats, and codec-local metrics.
+- RGB-D owners approve hardware/calibration/reconstruction changes.
+- Ryan owns QUEEN, 3DGStream, Gaussian training/quantization, CUDA rasterizers,
+  Gaussian semantics, upstream pins, correctness, and performance.
+
+Do not perform broad formatting, dependency, or conversion refactors across a
+research tree. First add parity evidence around the behavior you intend to
+reuse. In Gaussian directories, stop at the requested interface/handoff and
+seek Ryan's review.
+
+## Review checklist
+
+### Shared API or data format
+
+- Is the use case represented by a real provider/consumer?
+- Are defaults, optional dependencies, units, coordinate systems, timestamps,
+  topology, and failure semantics explicit?
+- Is unsupported data rejected rather than silently dropped?
+- Is there a compatibility/version story and a tiny golden fixture?
+- Does base import remain NumPy-only?
+
+### Codec or reconstruction change
+
+- Are algorithm changes separated from Open4D adapter changes?
+- Can decode/replay run from declared artifacts without original state?
+- Are output coordinates/time/metadata and all side information documented?
+- Are size, quality, speed, memory, and latency measured separately?
+- Are seeds, tool revisions, environment, and artifact hashes in the manifest?
+
+### Documentation/status change
+
+- Does it name audit commit, date, evidence level, and environment?
+- Does it separate upstream claims from Open4D verification?
+- Do commands and relative links resolve from their stated directory?
+- Does a green/complete label have an automated command behind it?
+
+## Definition of done for a new component
+
+A component is not `COMPLETE` until:
+
+1. clean setup from documented prerequisites succeeds;
+2. a redistributable or generated sample is available with provenance;
+3. one command runs the supported end-to-end path;
+4. a fresh process consumes only declared artifacts;
+5. the supported Open4D boundary is used;
+6. deterministic automated tests and manual matrices pass as appropriate;
+7. artifacts, output formats, limits, and cleanup are documented;
+8. license/provenance and exact distribution scope are approved;
+9. a run manifest proves revision, configuration, hashes, bytes, timings, and
+   metric version.

--- a/docs/handbook/v0.2-dev/glossary.md
+++ b/docs/handbook/v0.2-dev/glossary.md
@@ -1,0 +1,108 @@
+# Glossary
+
+Use this page while reading code, papers, and the roadmap. Definitions describe
+how the term is used in Open4D, not every possible meaning in graphics.
+
+| Term | Meaning |
+| --- | --- |
+| 3D | Three spatial coordinates, usually x/y/z. |
+| 4D | In this project, 3D geometry changing over time. |
+| AABB | Axis-aligned bounding box: minimum/maximum coordinates along each axis. Its diagonal is the current PSNR peak convention. |
+| ACK | Acknowledgement message. OBP1 ACKs identify the accepted pair and carry their own CRC. |
+| Adapter | Conversion at a boundary, such as Open4D geometry to Open3D, without taking ownership of storage or timing. |
+| ARAP | As-rigid-as-possible deformation, a way to deform geometry while locally resisting non-rigid distortion. |
+| Artifact | A file/bundle needed to reproduce or decode a run: bitstream, model, reference mesh, basis, transform, metadata, etc. |
+| Attribute | Numeric/boolean data aligned with mesh vertices, faces, or face corners. |
+| Basis | A set of directions/functions used to represent data; KLT stores coefficients in a learned linear basis. |
+| Bitrate | Bits per unit time. State whether this is codec payload, container, or wire bitrate. |
+| Calibration | Camera intrinsics/extrinsics and cross-camera transforms that map pixels/depth into consistent coordinates. |
+| C2C / point-to-point | Distance from each point/vertex to the nearest point/vertex in another set. |
+| C2P / point-to-plane | Nearest offset projected onto a reference normal; motion along the tangent plane is discounted. |
+| Chamfer distance | Usually a reduction of nearest-neighbor distances in both directions between point sets. Exact conventions vary. |
+| Clock domain | The clock that produced a timestamp, such as camera device, sender wall clock, receiver monotonic clock, or presentation timeline. |
+| Codec | Encoder/decoder rules that turn a representation into an artifact and back. Not a container or network protocol. |
+| COLMAP | Structure-from-motion/multi-view-stereo tooling and file formats used to estimate camera poses and sparse scene points. |
+| Container | A package for streams and metadata, such as an OpenUSD sequence file. |
+| Coordinate frame/system | Origin, axis directions/handedness, up axis, and units used by coordinates. |
+| Correspondence | A promise that an element (especially vertex index `i`) represents the same surface location across frames. |
+| CRC | Cyclic redundancy check used to detect accidental corruption; it is not authentication or encryption. |
+| Decoder state | Every value needed to decode: weights, reference/coarse mesh, basis/mean, normalization, topology, tables, dependencies, etc. |
+| Delta | An update that depends on a prior/base state rather than a self-contained frame. |
+| Depth image | Image whose pixels store distance from a camera rather than color. |
+| D1/D2 | MPEG-style geometry metrics commonly referring to point-to-point and point-to-plane variants; always name the implementation/convention. |
+| DRC | Common filename extension for a Draco-compressed geometry payload. |
+| Entropy coding | Lossless packing that gives likely symbols shorter representations. |
+| Epoch | A live-session generation used with session/frame IDs to distinguish reconnects or restarts. |
+| Extent | Geometry bounds, stored per time sample in the example USD container. |
+| Extrinsics | Transform from one camera/world coordinate frame to another. |
+| Face | A polygonal surface element. Open4D core stores triangles only. |
+| FPS | Frames per second. For irregular timestamps, Open4D's finite sequence reports average FPS. |
+| Frame | Geometry plus stored frame index, timestamp, and metadata. |
+| FrameProvider | Minimal finite storage/decoding contract: frame count plus random access, with optional declarations/cleanup. |
+| Free-viewpoint video (FVV) | A dynamic scene representation that can render viewpoints different from the captured cameras. |
+| Fresh-process decode | Starting a new decoder process with only declared artifacts; used to reveal hidden encoder/source dependencies. |
+| Gaussian splat / 3DGS | An oriented translucent 3D Gaussian with appearance parameters, rendered by projection/blending; not a triangle mesh. |
+| Goodput | Useful application data delivered per unit time, excluding protocol overhead and unusable/retransmitted data. |
+| GPU rasterizer | Specialized GPU code that turns geometry/Gaussians into image pixels. |
+| Handedness | Orientation convention relating x/y/z axes. |
+| Hausdorff distance | Maximum nearest distance between sets in both directions. Current example “Hausdorff” uses sampled vertices, not continuous surfaces. |
+| ICP | Iterative closest point alignment. Shared metrics do not run ICP automatically. |
+| Intrinsics | Camera focal length/principal point/distortion parameters mapping pixels and rays. |
+| Keyframe | Self-contained frame/base from which dependent deltas can be decoded. In example USD, also a topology-change sample. |
+| KLT | Karhunen–Loève Transform, equivalent to PCA under common conditions; a data-learned linear transform. |
+| Latency | Time between two named events on reconciled clocks. Always name endpoints, such as capture-to-present. |
+| Latent | Compact learned feature tensor consumed by a neural decoder. |
+| Laziness | Deferring decode/work until a frame or property actually needs it. |
+| LiveSource | Proposed unknown-length stream abstraction with buffering, time, dependency, closure, and failure semantics. It is not `Sequence`. |
+| Manifest | Structured record of revision, input, configuration, environment, artifacts/hashes/bytes, timing, and results. |
+| Marching cubes | Algorithm that extracts triangles approximating an isosurface, commonly the TSDF zero level. |
+| Material | Shading/appearance description referencing colors, textures, and parameters; not yet in Open4D core. |
+| Mesh | Vertices plus connectivity (and optional attributes) describing a surface. |
+| Metadata | Context not represented by the primary value fields. It should be documented, small, and not a hidden codec artifact. |
+| MRD1/MRD2/MRD3 | Reconstruction mesh/texture transport experiments: one-shot raw, one-shot Draco, and continuous Draco/JPEG respectively. |
+| Nearest neighbor | Closest sample in another set under a distance measure. |
+| Neural representation | A learned model/latent whose evaluation reconstructs a signal or geometry field. |
+| Normal | Direction perpendicular to a surface, used by lighting and point-to-plane metrics. |
+| NTC | Neural transformation cache used by 3DGStream to update Gaussians between frames. |
+| OBP1 | Versioned bounded protocol for a synchronized pair of compressed RGB-D camera observations. |
+| Open3D | External 3D processing/visualization library used by research and integration code. |
+| OpenUSD / USD | Scene/interchange framework with time sampling. Selected for Open4D offline interchange; not a codec. |
+| Ordinal | Position in a sequence. It may differ from the stored source `frame_index`. |
+| Payload bytes | Bytes produced by a codec or carried as message content, excluding any separately stated container/network overhead. |
+| PLY | Polygon File Format; used for per-frame mesh/point-cloud files. |
+| Point cloud | Unconnected 3D samples, often from depth cameras. Core lacks a first-class point-cloud type in v0.2-dev. |
+| Presentation timestamp | When a sample should be displayed on a declared playback timeline. |
+| PSNR | Peak signal-to-noise ratio in decibels. Requires both error convention and peak definition. Higher is better; exact match can be infinite. |
+| Quantization | Mapping values to fewer levels, introducing controlled loss and reducing representation size. |
+| Random access | Ability to request a particular finite frame without consuming all earlier frames. |
+| Reconstruction | Inferring 3D geometry/representation from observations such as RGB-D or multi-view images. |
+| Reference mesh | Base mesh against which temporal deformation/displacements are stored. |
+| Registration | Transforming data into a common coordinate frame. Shared metrics assume it is already done. |
+| Renderer | Produces images from a representation, camera, lighting, and appearance. |
+| RMS error | Square root of mean squared error; aggregation details determine whether frames/vertices have equal weight. |
+| SAM3 | Segmentation model vendored as a TSMC submodule for static/dynamic scene separation. |
+| Self-contained artifact | Bundle from which a fresh decoder reconstructs output without undeclared originals or encoder memory. |
+| Sequence | Open4D's finite lazy random-access temporal geometry abstraction. |
+| SequenceView | Lazy slice mapping into another sequence. |
+| Side information | Values besides primary coded symbols that decoding requires; they count toward a complete artifact. |
+| SDF | Signed distance field, whose zero level represents a surface. |
+| SSP | QNDF's surface simplification/subdivision/projection preprocessing path. |
+| SSIM | Structural Similarity Index, an image-quality metric. It is not a mesh-distance metric. |
+| StreamSample | Proposed live value carrying geometry/payload plus session, identity, time, dependencies, and statistics. |
+| Submodule | Git repository pinned inside another repository. An uninitialized submodule has a recorded commit but no checked-out contents. |
+| Texture | Image mapped to a surface, typically through UV coordinates. |
+| Timestamp | Numeric time value meaningful only with units and clock/timeline semantics. |
+| Topology | Mesh connectivity. Fixed topology means triangle indices remain invariant. |
+| TopologyMode | Open4D declaration: `FIXED`, `CHANGING`, or `UNKNOWN`. |
+| Transform | Mapping between coordinate frames, commonly a 4x4 homogeneous matrix. |
+| Triangle | Face connecting three vertex indices. |
+| TSDF | Truncated signed distance field; a bounded-band volumetric surface representation used for fusion/compression. |
+| UV | Two-dimensional texture coordinate, per vertex or face corner. |
+| V-DMC | MPEG video-based dynamic mesh coding test model/reference implementation. |
+| Vertex | Indexed 3D position used by mesh faces. |
+| Vertex-set metric | Metric evaluated on stored/sampled vertices rather than all points of continuous faces. |
+| Volume | 3D grid/field representation. Open4D core has no volume type in v0.2-dev. |
+| Voxel | One cell/sample of a 3D grid. |
+| WebRTC | Real-time communication stack; Open3D uses it here to serve the live browser view. |
+| Wire bytes | All bytes transmitted, including message/protocol overhead at the specified layer. |
+| Winding | Order of face vertices, normally controlling front direction and normal orientation. |

--- a/docs/handbook/v0.2-dev/implementation-status.md
+++ b/docs/handbook/v0.2-dev/implementation-status.md
@@ -28,11 +28,10 @@ flowchart TB
 | --- | --- | --- |
 | Versioned handbook | Source and root README link prepared; Wiki export committed locally with validated links | Initialize the enabled GitHub Wiki, push the prepared export, review, and merge this branch |
 | Explicit lightweight package allowlist | Implemented for exactly five packages; namespace discovery removed | Keep the provenance and archive assertions required in CI |
-| Exact distribution assertion | Wheel and source archive inventories pass locally | Confirm the packaging job on Blacksmith for this pull request |
+| Exact distribution assertion | Wheel and source archive inventories pass locally | Confirm the packaging job on GitHub-hosted runners for this pull request |
 | Third-party/provenance ledger | Root ledger covers the high-risk research, data, model, binary, paper, and submodule areas | Resolve each entry with immutable provenance and reviewed distribution terms |
 | License/distribution gate | Supported release workflow fails while `BLOCK` entries remain | Resolve TVMC, QNDF, copied-upstream, binary, dataset, checkpoint, and paper scope |
-| Continuous integration | Blacksmith workflow, Python/Open3D matrices, packaging smoke test, links, syntax, provenance, and release checks prepared | Verify all GitHub checks on this pull request |
-| CodeRabbit | Version-controlled automatic-review configuration prepared | Confirm the installed app reads the branch configuration on this pull request |
+| Continuous integration | GitHub Actions workflow, Python/Open3D matrices, packaging smoke test, links, syntax, provenance, and release checks prepared | Verify all GitHub-hosted checks on this pull request |
 | Protected merge policy | No repository ruleset recorded at the audit point | Require the verified CI checks after their exact GitHub check names exist |
 
 ## Verified baseline that remains
@@ -51,7 +50,7 @@ flowchart TB
 - Python 3.11, 3.12, and 3.13: 154 default tests pass on macOS.
 - Python 3.10: 78 core tests pass; the full local visualization tier is blocked
   by a SciPy macOS binary that the current linker rejects. The Linux
-  Blacksmith matrix is the authoritative remaining 3.10 check.
+  GitHub Actions matrix is the authoritative remaining 3.10 check.
 - Open3D 0.19 on Python 3.12: 5 adapter tests pass.
 - Exact wheel and source-distribution inventories pass, followed by a clean
   wheel installation and dependency check.
@@ -65,14 +64,14 @@ The working tree does **not** currently contain the proposed `open4d.io` or
 application, TVMC shared adapter, RGB-D finite replay adapter, or live-stream
 contract implementation. These are roadmap items, not current capabilities.
 
-CodeRabbit and Blacksmith are automation surfaces, not evidence by themselves.
-Their pull-request results must still prove the tests, packaging boundary,
-provenance containment, and release block implemented in this branch.
+GitHub Actions is an automation surface, not evidence by itself. Its
+pull-request results must still prove the tests, packaging boundary, provenance
+containment, and release block implemented in this branch.
 
 ## Immediate order of work
 
 1. Initialize and publish the enabled Wiki, then review and merge the handbook.
-2. Verify CodeRabbit and the complete Blacksmith matrix on the pull request.
+2. Verify the complete GitHub-hosted Actions matrix on the pull request.
 3. Configure protected-merge checks using the stable check names from that run.
 4. Resolve the provenance ledger's `BLOCK` entries; do not publish meanwhile.
 5. Begin P1 only after P0 acceptance criteria are green.

--- a/docs/handbook/v0.2-dev/implementation-status.md
+++ b/docs/handbook/v0.2-dev/implementation-status.md
@@ -1,0 +1,78 @@
+# Current implementation status
+
+The detailed [component register](status.md) is the immutable audit of commit
+`96b8c7b` on 2026-08-13. This page records the live gap between that baseline
+and the [90-day roadmap](roadmap.md). It must be updated when roadmap work is
+merged; planned or locally reverted work must not be reported as implemented.
+
+## Current platform graph
+
+```mermaid
+flowchart TB
+    Handbook["v0.2-dev handbook<br/>LOCAL DRAFT"]
+    P0["Packaging / CI / governance<br/>VERIFIED-PARTIAL"]
+    Core["Core model<br/>VERIFIED-PARTIAL"]
+    Examples["Example loaders / metrics / viewers<br/>VERIFIED-PARTIAL"]
+    Apps["End-to-end applications<br/>SCAFFOLD"]
+    Research["Independent research pipelines<br/>WORKING-ISOLATED"]
+
+    Handbook --> P0
+    Core --> Examples
+    Research -. "shared adapters missing" .-> Core
+    Core -. "vertical slice missing" .-> Apps
+```
+
+## P0 release-safety status
+
+| Work item | Current state | Next evidence required |
+| --- | --- | --- |
+| Versioned handbook | Source and root README link prepared; Wiki export committed locally with validated links | Initialize the enabled GitHub Wiki, push the prepared export, review, and merge this branch |
+| Explicit lightweight package allowlist | Implemented for exactly five packages; namespace discovery removed | Keep the provenance and archive assertions required in CI |
+| Exact distribution assertion | Wheel and source archive inventories pass locally | Confirm the packaging job on Blacksmith for this pull request |
+| Third-party/provenance ledger | Root ledger covers the high-risk research, data, model, binary, paper, and submodule areas | Resolve each entry with immutable provenance and reviewed distribution terms |
+| License/distribution gate | Supported release workflow fails while `BLOCK` entries remain | Resolve TVMC, QNDF, copied-upstream, binary, dataset, checkpoint, and paper scope |
+| Continuous integration | Blacksmith workflow, Python/Open3D matrices, packaging smoke test, links, syntax, provenance, and release checks prepared | Verify all GitHub checks on this pull request |
+| CodeRabbit | Version-controlled automatic-review configuration prepared | Confirm the installed app reads the branch configuration on this pull request |
+| Protected merge policy | No repository ruleset recorded at the audit point | Require the verified CI checks after their exact GitHub check names exist |
+
+## Verified baseline that remains
+
+- NumPy-backed `TriangleMesh`, `Frame`, finite lazy `Sequence`, and their
+  existing tested behaviors.
+- Example sequence loaders, comparison tools, viewers, and Open3D conversion
+  within the scopes recorded in the component register.
+- Independent codec and reconstruction research trees, without a common
+  Open4D adapter or complete end-to-end application.
+- Checksum-based artifact-fetching policy and the component-specific mechanics
+  explicitly identified in the handbook as worth preserving.
+
+## Local verification snapshot
+
+- Python 3.11, 3.12, and 3.13: 154 default tests pass on macOS.
+- Python 3.10: 78 core tests pass; the full local visualization tier is blocked
+  by a SciPy macOS binary that the current linker rejects. The Linux
+  Blacksmith matrix is the authoritative remaining 3.10 check.
+- Open3D 0.19 on Python 3.12: 5 adapter tests pass.
+- Exact wheel and source-distribution inventories pass, followed by a clean
+  wheel installation and dependency check.
+- Markdown links, Python compilation, shell syntax, provenance containment,
+  release-block presence, and whitespace checks pass locally.
+
+## Not currently implemented
+
+The working tree does **not** currently contain the proposed `open4d.io` or
+`open4d.metrics` public packages, schema-v1 USD API, complete Draco reference
+application, TVMC shared adapter, RGB-D finite replay adapter, or live-stream
+contract implementation. These are roadmap items, not current capabilities.
+
+CodeRabbit and Blacksmith are automation surfaces, not evidence by themselves.
+Their pull-request results must still prove the tests, packaging boundary,
+provenance containment, and release block implemented in this branch.
+
+## Immediate order of work
+
+1. Initialize and publish the enabled Wiki, then review and merge the handbook.
+2. Verify CodeRabbit and the complete Blacksmith matrix on the pull request.
+3. Configure protected-merge checks using the stable check names from that run.
+4. Resolve the provenance ledger's `BLOCK` entries; do not publish meanwhile.
+5. Begin P1 only after P0 acceptance criteria are green.

--- a/docs/handbook/v0.2-dev/implementation-status.md
+++ b/docs/handbook/v0.2-dev/implementation-status.md
@@ -28,10 +28,11 @@ flowchart TB
 | --- | --- | --- |
 | Versioned handbook | Source and root README link prepared; Wiki export committed locally with validated links | Initialize the enabled GitHub Wiki, push the prepared export, review, and merge this branch |
 | Explicit lightweight package allowlist | Implemented for exactly five packages; namespace discovery removed | Keep the provenance and archive assertions required in CI |
-| Exact distribution assertion | Wheel and source archive inventories pass locally | Confirm the packaging job on GitHub-hosted runners for this pull request |
+| Exact distribution assertion | Wheel and source archive inventories pass locally | Confirm the packaging job on Blacksmith for this pull request |
 | Third-party/provenance ledger | Root ledger covers the high-risk research, data, model, binary, paper, and submodule areas | Resolve each entry with immutable provenance and reviewed distribution terms |
 | License/distribution gate | Supported release workflow fails while `BLOCK` entries remain | Resolve TVMC, QNDF, copied-upstream, binary, dataset, checkpoint, and paper scope |
-| Continuous integration | GitHub Actions workflow, Python/Open3D matrices, packaging smoke test, links, syntax, provenance, and release checks prepared | Verify all GitHub-hosted checks on this pull request |
+| Continuous integration | Blacksmith-backed GitHub Actions workflow, Python/Open3D matrices, packaging smoke test, links, syntax, provenance, and release checks prepared | Verify all GitHub checks on this pull request |
+| CodeRabbit | Version-controlled automatic-review configuration enabled for draft and ready pull requests | Confirm the installed app reviews this pull request |
 | Protected merge policy | No repository ruleset recorded at the audit point | Require the verified CI checks after their exact GitHub check names exist |
 
 ## Verified baseline that remains
@@ -50,7 +51,7 @@ flowchart TB
 - Python 3.11, 3.12, and 3.13: 154 default tests pass on macOS.
 - Python 3.10: 78 core tests pass; the full local visualization tier is blocked
   by a SciPy macOS binary that the current linker rejects. The Linux
-  GitHub Actions matrix is the authoritative remaining 3.10 check.
+  Blacksmith matrix is the authoritative remaining 3.10 check.
 - Open3D 0.19 on Python 3.12: 5 adapter tests pass.
 - Exact wheel and source-distribution inventories pass, followed by a clean
   wheel installation and dependency check.
@@ -64,14 +65,14 @@ The working tree does **not** currently contain the proposed `open4d.io` or
 application, TVMC shared adapter, RGB-D finite replay adapter, or live-stream
 contract implementation. These are roadmap items, not current capabilities.
 
-GitHub Actions is an automation surface, not evidence by itself. Its
-pull-request results must still prove the tests, packaging boundary, provenance
-containment, and release block implemented in this branch.
+CodeRabbit and Blacksmith are automation surfaces, not evidence by themselves.
+Their pull-request results must still prove the tests, packaging boundary,
+provenance containment, and release block implemented in this branch.
 
 ## Immediate order of work
 
 1. Initialize and publish the enabled Wiki, then review and merge the handbook.
-2. Verify the complete GitHub-hosted Actions matrix on the pull request.
+2. Verify CodeRabbit and the complete Blacksmith matrix on the pull request.
 3. Configure protected-merge checks using the stable check names from that run.
 4. Resolve the provenance ledger's `BLOCK` entries; do not publish meanwhile.
 5. Begin P1 only after P0 acceptance criteria are green.

--- a/docs/handbook/v0.2-dev/platform.md
+++ b/docs/handbook/v0.2-dev/platform.md
@@ -1,0 +1,233 @@
+# Core, I/O, OpenUSD, and metrics
+
+This chapter distinguishes the supported v0.2-dev core from working example
+code and from the next public APIs. That distinction matters when you build a
+codec adapter: importing an example by modifying `sys.path` is not a stable
+platform interface.
+
+## Public core model
+
+The root `open4d` package exports:
+
+- `TriangleMesh`
+- `Frame`
+- the `FrameProvider` protocol and `MemoryFrameProvider`
+- `Sequence`, `SequenceView`, and `TopologyMode`
+- canonical dtype constants and the `dtypes` module
+
+The base dependency is NumPy. Heavy readers, renderers, ML frameworks, and
+codec dependencies should remain optional.
+
+### TriangleMesh
+
+`TriangleMesh` validates array shape, numeric/boolean type, finite values,
+triangle bounds, color range, and attribute alignment. Its canonical storage is:
+
+| Field | Shape | Stored dtype/range |
+| --- | --- | --- |
+| `positions` | `(N, 3)` | `float32` |
+| `triangles` | `(M, 3)` | `uint32` |
+| `colors` | `(N, 3)` or `(N, 4)` | `float32`, `[0, 1]` |
+| `normals` | `(N, 3)` | `float32` |
+| `texture_coordinates` | `(N, 2)` or `(M, 3, 2)` | `float32` |
+| float attributes | first dimension vertex/face/corner aligned | `float32` |
+| integer attributes | first dimension vertex/face/corner aligned | `int32` |
+| boolean attributes | first dimension vertex/face/corner aligned | `bool` |
+
+The object is structurally immutable, but its NumPy buffers are not forced
+read-only. Canonical arrays may be shared zero-copy with the caller. Preserve
+this policy unless a measured need and migration plan justify changing it.
+
+The current gap is integer attribute narrowing: indices are range-checked before
+conversion, but generic integer attributes also need an explicit `int32` range
+check so a large value cannot wrap silently.
+
+### Frame
+
+`Frame(frame_index, timestamp, geometry, metadata)` validates a nonnegative
+integer source index, finite real timestamp, `TriangleMesh`, and mapping
+metadata. Metadata is a shallow read-only snapshot. It is not a place to hide a
+codec's encoded state.
+
+### FrameProvider and Sequence
+
+A provider must expose `frame_count` and `get_frame(index)`. It may declare
+metadata, a timestamp table, topology, constant vertex count, correspondence,
+and `close()`.
+
+`Sequence` provides:
+
+- finite length and ordinal indexing, including negative indices;
+- iteration and lazy slice views;
+- provider metadata and topology declarations;
+- validated nondecreasing timestamps, duration, and average FPS;
+- context-manager cleanup.
+
+Construction reads declarations only. Integer access asks the provider for one
+frame. Requesting timestamps can decode every frame when the provider has no
+timestamp table. A `SequenceView` is lazy, although its timestamp property reads
+parent frames through the view provider.
+
+Topology flags are promises, not results of an automatic scan. `FIXED` implies
+constant topology, vertex count, and correspondence unless the provider makes a
+more specific declaration; `UNKNOWN` correctly returns `None` when evidence is
+insufficient.
+
+## Working example I/O
+
+`examples/visualization/frame_sources.py` currently provides the one-call loader:
+
+```python
+from frame_sources import open_sequence
+
+with open_sequence("frames/", fps=30.0) as sequence:
+    frame = sequence[0]
+```
+
+Supported sources are:
+
+| Source | Base/extra | Current behavior |
+| --- | --- | --- |
+| folder of `.obj`/`.ply` | base NumPy | lazy listing/provider; last filename number controls order |
+| one `.obj`/`.ply` | base NumPy | single fixed frame |
+| folder or one `.usd/.usda/.usdc/.usdz` | `.[usd]` | lazy USD provider |
+| `.off/.stl/.glb/.gltf` | `.[tools]` | trimesh fallback |
+
+Important limitations:
+
+- OBJ reads positions/faces but ignores normals, UVs, groups, materials, and
+  colors; polygons are fan-triangulated.
+- built-in PLY reads positions, triangles, and RGB; unusual PLY variants fall
+  back to trimesh.
+- mixed-format folders choose the most common suffix and skip the others.
+- ordering uses the **last** integer in the filename, so `frame_003_qp9.obj`
+  sorts on 9 and can silently misalign comparisons.
+- zero-face geometry stands in for point clouds because core has no point type.
+
+The P1 public interface is:
+
+```python
+open4d.io.open_sequence(path, fps=None) -> Sequence
+open4d.io.write_usd_container(path, frames, ...) -> pathlib.Path
+```
+
+Examples should become thin clients of those functions. Promotion must keep
+construction lazy, add cleanup and malformed-source tests, and use actionable
+optional-dependency errors.
+
+## OpenUSD container
+
+OpenUSD is the selected primary **offline interchange container**, not a
+compression algorithm. The example writer already creates time-sampled
+`UsdGeom.Mesh` or `UsdGeom.Points` data with:
+
+- positions and bounds per frame;
+- triangle connectivity once for fixed topology or at key frames;
+- per-vertex display color when present;
+- custom frame index, timestamp, keyframe, vertex-count, and triangle-count
+  streams;
+- stage FPS/time range/up axis and `customLayerData["open4d"]` metadata.
+
+The example format labels its container metadata version `1`, but it is not yet
+the ratified Open4D schema v1. Known fidelity and validation gaps are:
+
+- normals, UVs, named attributes, materials, and general frame metadata are not
+  round-tripped;
+- the reader places stored frame-index streams into metadata but constructs
+  frames with ordinal indices;
+- the first frame chooses Mesh versus Points, so a later mixed sequence is not
+  rejected explicitly and may lose connectivity;
+- an empty position array fails when the writer calculates min/max extent;
+- any `up_axis` other than `"z"` becomes Y; X is not explicitly rejected;
+- transform, units, and coordinate-frame semantics are not first-class.
+
+Schema v1 must preserve positions, triangles, colors, normals, UVs, named
+attributes, stored timestamps/frame indices, sequence metadata, and topology
+declarations. It must support Y-up and Z-up, reject X-up for now, omit extents
+safely for empty geometry, and reject mixed Mesh/Points sequences rather than
+silently dropping data. Unsupported values must fail explicitly.
+
+## Working example metrics
+
+The current metric implementation lives in
+`examples/visualization/mesh_metrics.py` and `compare_frames.py`.
+
+For each frame it computes nearest-vertex distances in both directions:
+
+```text
+decoded -> reference   catches displaced/extra decoded vertices
+reference -> decoded   catches geometry the decoder deleted
+```
+
+`point` uses Euclidean nearest-vertex distance. `plane` projects the offset
+onto the nearest reference vertex normal and falls back to point distance when
+a usable normal is unavailable. Symmetric RMS and maximum use the worse
+direction; symmetric PSNR uses the lower direction. One reference bounding-box
+diagonal is used as the peak for all compared frames.
+
+Scientific limits must be stated with every result:
+
+- distances are between **vertex sets**, not continuous triangle surfaces;
+- “Hausdorff” is therefore the worse sampled vertex maximum, not exact surface
+  Hausdorff distance;
+- results are not face-area weighted;
+- inputs are not ICP-aligned, registered, rescaled, or unit-converted;
+- point-to-plane depends on computed vertex normals and winding/degeneracy;
+- identical meshes produce infinite PSNR; a degenerate peak produces NaN.
+
+Current sequence behavior also needs hardening:
+
+- unequal sequences silently compare through the shorter sequence and record a
+  truncation note;
+- sequence RMS is an RMS of per-frame symmetric RMS values, not a pooled
+  per-vertex error;
+- sequence PSNR is an arithmetic mean of per-frame PSNR;
+- `worst_frame` is an index into comparison results, not the stored source frame
+  index.
+
+The P1 public interface is:
+
+```python
+open4d.metrics.compare_meshes(...)
+open4d.metrics.compare_sequences(..., allow_truncate=False)
+```
+
+Lengths must match by default. Explicit truncation may retain the current
+behavior. Sequence RMS/PSNR must pool error with one documented peak, and reports
+must retain original frame indices. Publish an algorithm identifier such as
+`open4d.vertex-nearest/v1` so old paper results remain interpretable after a
+metric improves.
+
+## Viewers and adapters
+
+The PyQt viewers decode and measure the selected display frames up front, then
+provide orbit, zoom, scrub, stepping, playback, GIF output, fixed sequence-wide
+error colors, and synchronized comparison cameras. Preserve existing comparison
+behavior while moving only stable loader/metric/container code into the package.
+
+The Open3D integration converts Open4D geometry or compatible arrays into an
+Open3D `TriangleMesh` or `PointCloud`, preserving vertex colors/normals. It does
+not carry texture coordinates/materials and must remain an external frame
+operation; Open3D should not own timing or laziness.
+
+`open4d.torch_ops` replaces the small subset of PyTorch3D previously used by
+research codecs: geometry-only OBJ I/O, normal computation, surface sampling,
+Chamfer distance, and point-to-face distance. Keep its tested numerical
+semantics, but do not make Torch the base data model.
+
+## Run manifest v1
+
+Every complete vertical slice should emit `open4d.run-manifest/v1` containing:
+
+- Open4D commit and dirty-state indication;
+- source URI/name, license, content hash, frame range, frame indices/timestamps;
+- codec identifier/version and complete normalized configuration;
+- every required artifact path, SHA-256, role, and actual byte count;
+- environment: OS, Python/tool versions, CPU/GPU, relevant driver/CUDA;
+- encode/decode/stage timings and measurement method;
+- metric identifier, peak convention, configuration, and results;
+- payload, filesystem/container, and (when applicable) wire byte counts as
+  separate values.
+
+The manifest must be sufficient to decide what a fresh decoder needs and to
+distinguish a paper claim from a reproduced run.

--- a/docs/handbook/v0.2-dev/primer.md
+++ b/docs/handbook/v0.2-dev/primer.md
@@ -1,0 +1,191 @@
+# 3D and 4D geometry primer
+
+This chapter gives you enough vocabulary to read the Open4D code and papers. It
+deliberately starts from data, not rendering mathematics.
+
+## Coordinates and coordinate systems
+
+A 3D position is normally written `(x, y, z)`. The three numbers are meaningful
+only with a coordinate system:
+
+- **origin**: where `(0, 0, 0)` is;
+- **axes**: which directions are positive x, y, and z;
+- **handedness**: the orientation relationship among the axes;
+- **up axis**: often Y in graphics tools and Z in robotics/data capture;
+- **units**: metres, millimetres, or an arbitrary normalized cube;
+- **transform**: a rotation, translation, and sometimes scale mapping one
+  coordinate system to another.
+
+Two meshes can look identical but measure as wildly different if one is in
+metres and one in millimetres, or if their origins differ. The current shared
+`TriangleMesh` stores scene-local coordinates but has no first-class transform,
+units, or coordinate-frame field. Producers must therefore record these in
+frame/sequence metadata and evaluators must not silently align meshes.
+
+## Triangle meshes
+
+A triangle mesh uses two main arrays:
+
+```text
+positions[N, 3]   one xyz point for each vertex
+triangles[M, 3]   three integer vertex indices for each triangular face
+```
+
+For example, triangle `[0, 3, 2]` connects positions 0, 3, and 2. The order is
+the **winding** and normally determines which side is the front.
+
+Common optional data includes:
+
+- **normals**: directions used for lighting or point-to-plane distance;
+- **colors**: RGB or RGBA values, usually per vertex;
+- **UV coordinates**: 2D coordinates that map mesh corners or vertices into an
+  image texture;
+- **materials/textures**: rules and images describing surface appearance;
+- **attributes**: application-specific arrays aligned with vertices, faces, or
+  face corners.
+
+Open4D's current core represents triangle meshes, colors, normals, UVs, and
+named numeric/boolean attributes. It does not yet model materials.
+
+## Topology and correspondence
+
+**Topology** means connectivity: which vertices make each face. Two frames have
+fixed topology when the triangle-index array is unchanged. This is different
+from vertex count: frames may have the same number of vertices but connect them
+differently.
+
+**Vertex correspondence** means vertex `i` represents the same physical or
+semantic surface location over time. A temporal codec can store one reference
+mesh plus per-vertex motion only when this correspondence exists. Independently
+reconstructing a surface with marching cubes usually produces a new set and
+ordering of vertices each frame, even if the object is the same.
+
+Open4D declares, rather than guesses, these properties:
+
+- `TopologyMode.FIXED`: connectivity is invariant;
+- `TopologyMode.CHANGING`: connectivity changes;
+- `TopologyMode.UNKNOWN`: the provider cannot promise either without scanning.
+
+## Point clouds
+
+A point cloud is a set of 3D samples, often with colors and normals, but no
+faces connecting them. RGB-D cameras naturally produce point clouds: each valid
+depth pixel becomes a point after applying camera calibration.
+
+The v0.2-dev core has no `PointCloud` type. Example loaders temporarily represent
+points as a `TriangleMesh` with zero triangles. That is a compatibility bridge,
+not the intended long-term model.
+
+## Voxels, signed distance fields, and TSDFs
+
+A **voxel** is a 3D grid cell, the volumetric analogue of a pixel. A signed
+distance field stores at each location the distance to the nearest surface:
+positive on one side, negative on the other, and zero at the surface.
+
+A **truncated signed distance field (TSDF)** stores this value only within a
+limited distance of the surface. Truncation makes fusion and storage practical.
+Multiple depth images can be integrated into one TSDF; a triangle mesh is then
+extracted from the zero crossing, commonly with marching cubes.
+
+Consequences that matter in this repository:
+
+- RGB-D fusion and N4MC/KLT use volumetric representations internally.
+- Marching cubes generally changes topology and vertex ordering each frame.
+- A TSDF tensor should eventually get its own volume type; it should not be
+  hidden inside `TriangleMesh`.
+
+## Gaussian splats
+
+A 3D Gaussian splat is a small, soft, oriented blob rather than a triangle.
+Typical parameters include position, scale/covariance, orientation, opacity,
+and view-dependent color coefficients. Thousands or millions are projected and
+blended to render a view. Dynamic Gaussian methods update those parameters or
+add/remove Gaussians over time.
+
+Gaussian splats are excellent for photorealistic novel views but are not meshes:
+they have no triangle connectivity, use a specialized differentiable renderer,
+and their quality is normally evaluated in rendered images. QUEEN and
+3DGStream therefore live with reconstruction. Ryan owns their algorithms,
+training, quantization, CUDA rasterizers, and representation contract.
+
+## Frames and sequences
+
+A **frame** is geometry plus temporal identity:
+
+```text
+Frame
+  frame_index   stored source identifier (nonnegative integer)
+  timestamp     time in seconds on a declared clock/timeline
+  geometry      currently TriangleMesh
+  metadata      lightweight context
+```
+
+A **sequence** is an ordered, finite collection of frames. Open4D's `Sequence`
+is lazy and random-access: construction reads provider declarations; requesting
+frame 20 asks the provider to decode frame 20. A slice is a view, not a copied
+list of decoded meshes.
+
+Frame index and ordinal position are different. `sequence[3]` asks for the
+fourth stored element; that frame's `frame_index` might be 120 if the source was
+subsampled. Metrics and manifests need to preserve both.
+
+## Time and clocks
+
+A filename number is not automatically a timestamp. For files with no timing,
+the example loader synthesizes timestamps from a supplied FPS. Live systems may
+have several clocks:
+
+- camera device time;
+- sender monotonic or wall-clock time;
+- receiver time;
+- presentation time used by playback.
+
+Clock domain, units, and synchronization error must travel with measurements.
+Subtracting timestamps from unrelated clocks does not produce latency.
+
+## Compression concepts
+
+Compression removes redundancy. The main ideas used here are:
+
+- **quantization**: store a value with fewer discrete levels;
+- **transform coding**: rotate data into a basis where few coefficients matter
+  (KLT/PCA is the classical example);
+- **prediction/reference coding**: store changes from a previous/reference
+  shape instead of every full shape;
+- **neural representation**: train a compact network/latent code that generates
+  geometry or a field;
+- **entropy coding**: turn likely symbols into fewer bits without further loss;
+- **keyframe and delta**: a self-contained base followed by dependent updates.
+
+An encoded artifact is self-contained only when a fresh decoder needs no
+original source, in-memory encoder values, or undeclared files. Model weights,
+bases, means, normalization transforms, topology, and entropy side information
+all count toward the artifact when decoding requires them.
+
+## Containers, codecs, and transports
+
+- A **codec** defines how data is encoded and decoded.
+- A **container** packages one or more streams and metadata on disk. OpenUSD is
+  the planned primary offline interchange container.
+- A **transport/protocol** frames data across a network and defines ordering,
+  bounds, errors, and acknowledgements.
+
+Draco can compress a mesh payload inside a container or network message. It
+does not itself specify a time sequence, clock synchronization, reconnect
+behavior, or playback buffering.
+
+## Evaluation basics
+
+Quality and systems performance are separate dimensions:
+
+- geometric RMS/maximum error and PSNR;
+- image PSNR/SSIM/LPIPS for rendered Gaussian views;
+- codec payload bytes, container bytes, and wire bytes;
+- encode/decode time and peak memory;
+- capture-to-decode and capture-to-present latency;
+- throughput, goodput, startup time, and drops at each queue.
+
+Current shared example metrics compare vertex sets with nearest-neighbor
+point-to-point or point-to-plane distances in both directions. They are useful
+cross-codec baselines, but they are not continuous, area-weighted surface
+metrics and they do not register or align inputs.

--- a/docs/handbook/v0.2-dev/reconstruction-streaming.md
+++ b/docs/handbook/v0.2-dev/reconstruction-streaming.md
@@ -1,0 +1,186 @@
+# Reconstruction and streaming
+
+Reconstruction creates a 3D representation from sensor observations. Streaming
+moves observations or encoded representations between machines. The current
+repository has both jobs, but not one unified live-geometry architecture.
+
+## RGB-D in plain language
+
+An RGB-D camera produces a color image and a depth image. Camera calibration
+maps a depth pixel to a 3D ray and maps depth/color sensors into a common camera
+coordinate system. Multi-camera calibration maps camera 2 into camera 1's
+coordinates. If timing or calibration is wrong, two otherwise correct point
+clouds appear doubled or torn.
+
+The maintained Python two-camera path is:
+
+```mermaid
+flowchart LR
+    Cams["two hardware-synchronized RGB-D cameras"] --> Sender["Windows capture sender"]
+    Sender -->|"OBP1 over localhost/SSH tunnel"| Receiver["Ubuntu receiver"]
+    Receiver --> Decode["JPEG color + compressed depth decode"]
+    Decode --> Prep["calibration + point-cloud preparation"]
+    Prep --> Cloud["aligned fused point cloud"]
+    Prep --> TSDF["CUDA TSDF integration"]
+    TSDF --> Mesh["mesh extraction / merge"]
+    Cloud --> WebRTC["Open3D WebRTC browser view"]
+    Mesh --> WebRTC
+    Cloud --> Disk["latest PLY + JSON report"]
+    Mesh --> Disk
+```
+
+The point cloud updates for processed camera pairs. Mesh rebuilding happens
+periodically over a bounded recent window; it is not a continuous compressed
+mesh stream. The default independent-merge mode reconstructs each camera in its
+own TSDF and transforms/concatenates or welds meshes. Shared-TSDF integrates
+both cameras in one volume. The full paper-style overlap removal/stitching is
+not implemented.
+
+The receiver uses bounded latest-result queues (`maxsize=1`) and bounded history
+deques, replacing stale work rather than allowing unbounded latency/memory.
+Preserve that behavior.
+
+The C++ tree is the original native lane: K4A-compatible live/recorded capture,
+CUDA texture mapping/reconstruction, PLY/OBJ/texture/Draco output, metrics, and
+mesh transport. It has a CUDA texture-mapping test but was not built in this
+audit.
+
+## Calibration and metadata
+
+A reproducible captured pair needs more than color/depth bytes. Finalized replay
+should preserve:
+
+- pair number and original source frame identifiers;
+- both device timestamps and sender timestamp;
+- synchronization error and hardware-sync flags;
+- sender/receiver/drop counters at each queue;
+- factory intrinsics/extrinsics and camera-to-reference transform;
+- units and coordinate-frame convention;
+- reconstruction backend, parameters, fusion/merge modes, and timings.
+
+The current live classes carry much of this across protocol structures and JSON
+reports, but completed meshes are Open3D values rather than
+`Frame(TriangleMesh)`, and there is no finite provider over a recording.
+
+P3 should add a tiny camera-free replay, convert completed mesh results to
+changing-topology frames, and reopen a finalized recording as a finite
+`Sequence`. That is a replay/recording boundary, not a reason to make `Sequence`
+infinite.
+
+## Current network protocols
+
+| Protocol | Direction/purpose | Payload and metadata | Safety already present | Status/direction |
+| --- | --- | --- | --- | --- |
+| OBP1 | capture sender to RGB-D fusion receiver | one synchronized pair; color/depth descriptors, serials, formats, dimensions, raw/compressed lengths, pair/timestamps/sync/drop fields | version/magic, header and payload CRCs, maximum counts/sizes, exact receive, ACK with CRC and pair number | preserve; add golden/reconnect/sequence tests |
+| MRD1 | native reconstruction to one-shot client | raw positions, normals, indices, per-corner UVs, RGB8 texture | fixed header and payload-size validation in reference receiver | retain as one-shot fixture |
+| MRD2 | native reconstruction to one-shot client | Draco geometry and raw RGB8 texture | fixed header and texture-size checks | retain as one-shot fixture |
+| MRD3 | native reconstruction continuous output | per-frame Draco geometry + JPEG image, frame ID, split 64-bit timestamp, counts/drop fields | magic/version/codec checks in receiver | experimental; not the future general envelope |
+| raw Unity path | native direct sender/consumer experiment | implementation-specific mesh buffers | no shared contract | deprecate rather than expand |
+
+OBP1 source bounds include at most 8 payloads, a 4 KiB header, 32 MiB total
+compressed payload, 12 MiB per compressed payload, and 16 MiB declared raw
+payload. A successful receive validates both the header and each payload before
+returning a frame. These are meaningful protocol invariants and should get
+binary golden tests rather than a rewrite.
+
+Required OBP1 tests include fragmented reads, header/payload CRC failures,
+oversize declarations, descriptor-total mismatch, malformed/too-long serials,
+ACK mismatch/corruption, clean shutdown, timeout, reconnect, gaps, duplicates,
+timestamp preservation, bounded queue replacement, and bounded memory.
+
+## Future live-source contract
+
+The P3 deliverable is a specification plus deterministic replay tests, not a
+production Internet transport. A future `LiveSource[T]` and `StreamSample[T]`
+must define at least:
+
+| Field/behavior | Why it is required |
+| --- | --- |
+| session ID and epoch | distinguish a reconnect/restart from delayed old data |
+| unsigned 64-bit frame ID | stable ordering beyond short demonstrations |
+| presentation timestamp and clock domain | schedule playback and calculate valid latency |
+| content/representation type | distinguish mesh, points, volume, Gaussian, or codec payload |
+| keyframe/base dependency | know whether a delta is decodable after loss/reconnect |
+| buffer and drop policy | make latency/memory behavior deterministic |
+| source/queue/consumer statistics | attribute drops and throughput correctly |
+| end, close, cancellation, and error semantics | finalize recordings and release resources |
+| recording/freeze operation | turn a bounded session into a finite provider/`Sequence` |
+
+Do not collapse performance into one “bitrate” or “latency.” Record codec
+payload bitrate, container/wire bitrate, useful goodput, capture-to-decode,
+capture-to-present, startup, and drop counts at capture, sender, network,
+receiver, preparation, reconstruction, decode, and presentation separately.
+
+For the 90-day horizon, localhost listeners plus SSH tunneling are the supported
+remote-security model. Authenticated encryption, Internet exposure,
+multi-client delivery, rate adaptation, jitter buffering, and reconnect-to-
+keyframe behavior are post-contract work.
+
+## Unity
+
+The Unity integration is a specialized TVMC playback stack: a C++ decoder uses
+reference geometry, anchor/basis/trajectory data and windowed subsequences; C#
+updates Unity meshes for desktop or Quest. Prebuilt macOS and Android libraries,
+an encoded example zip, helper conversion scripts, and C++ source are tracked.
+
+It is useful isolated code, not a generic Open4D player. Before extending it,
+the project must choose one of two dispositions:
+
+1. repair and support it by reconciling source/prebuilt C ABI, C# class/file
+   naming, buffer eviction, build matrix, and a tiny artifact test; or
+2. clearly label it legacy/prebuilt-only.
+
+TSMC/generic playback remains separate future work. Do not route the new live
+contract through the old raw transport by default.
+
+## Gaussian splats: Ryan's ownership boundary
+
+The audited tree contains full sibling directories
+`open4d/reconstruction/queen/` and `open4d/reconstruction/3dgstream/`.
+`open4d/reconstruction/gs_tools/` is only a placeholder README. Documentation
+that says QUEEN and 3DGStream live under `gs_tools` is stale; the deleted design
+must not be recreated without Ryan's agreement.
+
+### QUEEN
+
+QUEEN trains dynamic 3D Gaussians from calibrated multi-view images. Its
+research implementation uses a dense/initial frame plus quickly trained,
+quantized residual-frame data and specialized CUDA rasterizers. It reports
+free-viewpoint image quality, storage, training time, and render speed. The
+vendored tree includes NVIDIA/non-commercial and other third-party terms, CUDA
+extensions, MiDaS, Docker/environment setup, rendering, and evaluation scripts.
+
+### 3DGStream
+
+3DGStream starts from a high-quality initial 3D Gaussian model. For later
+frames, a neural transformation cache updates existing Gaussians and additional
+Gaussians model newly visible content. It requires calibrated multi-view frame
+directories, COLMAP data, CUDA/tiny-cuda-nn, preprocessing/warm-up, and a
+specialized renderer/viewer. The tracked test assets are large and should move
+only through a provenance-preserving artifact plan.
+
+### What Ryan owns
+
+Ryan owns:
+
+- QUEEN and 3DGStream algorithms and training/quantization behavior;
+- CUDA rasterizers and GPU environments;
+- Gaussian representation semantics and correctness/performance;
+- upstream pinning or vendoring decisions.
+
+General platform contributors must not refactor these directories or invent a
+Gaussian core type. The shared platform may request this handoff, reviewed by
+Ryan:
+
+- exact upstream revisions and local patch list;
+- third-party license/provenance inventory;
+- one reproducible GPU command and a licensed two-frame smoke artifact;
+- input manifest for images, intrinsics, extrinsics, timestamps, splits, and
+  COLMAP data;
+- output manifest for initial state, per-frame deltas, coordinate system,
+  units, time, sizes, and renderer requirements;
+- renderer-ready buffer or artifact contract;
+- self-contained keyframe semantics and explicit delta dependencies.
+
+Until that handoff, both methods remain `OWNER-RYAN`, excluded from the
+lightweight wheel, and unverified by shared-platform acceptance tests.

--- a/docs/handbook/v0.2-dev/repository-map.md
+++ b/docs/handbook/v0.2-dev/repository-map.md
@@ -1,0 +1,105 @@
+# Repository and feature map
+
+This map describes what is physically present at the audited revision and how
+each area should align with the platform.
+
+## Top-level map
+
+```text
+Open4D/
+├── open4d/                 shared package plus research implementations
+│   ├── core/               NumPy geometry/frame/provider/sequence model
+│   ├── torch_ops/          small Torch mesh/I/O replacements
+│   ├── codecs/             eight codec or reference-codec areas
+│   └── reconstruction/     RGB-D, QUEEN, 3DGStream, gs_tools placeholder
+├── examples/visualization/ working loaders, USD, metrics, renderers, viewers
+├── integrations/           Open3D conversion and Unity TVMC playback
+├── apps/                   end-to-end application scaffold (README only)
+├── scripts/                setup, artifact, and data helper scripts
+├── docs/                   design, policy, media, and this handbook
+├── pyproject.toml          lightweight package metadata and extras
+├── environment.yml         shared Python 3.12 codec environment
+├── requirements-*.txt      shared codec and machine-specific GPU dependencies
+└── README.md               project overview and setup
+```
+
+Local `build/`, `open4d.egg-info/`, `.pytest_cache/`, and `.context/` directories
+are generated or workspace state, not product architecture. Do not document or
+import from them.
+
+## Feature alignment matrix
+
+| Area | What it does | Inputs | Outputs | Main dependencies | Who uses it | Open4D alignment |
+| --- | --- | --- | --- | --- | --- | --- |
+| `open4d/core` | validates meshes and represents finite time sequences lazily | NumPy-compatible arrays, provider objects | `TriangleMesh`, `Frame`, `Sequence` | NumPy | all future loaders/codecs/metrics | canonical shared boundary; preserve |
+| `open4d/torch_ops` | replaces a handful of PyTorch3D mesh and OBJ functions | Torch tensors, OBJ | tensors / local `Mesh` | PyTorch | N4MC, QNDF | dependency-reduction utility, not the public data model |
+| `examples/visualization` | opens sequences, writes USD, compares and displays frames | mesh folders, mesh files, USD | `Sequence`, CSV, USD, GIF/window | optional SciPy, PyQt6, OpenGL, OpenUSD, trimesh | contributors and codec evaluation | working prototype to promote into public APIs |
+| `integrations/open3d` | converts frame-like values to Open3D mesh/point cloud | Open4D geometry or compatible arrays | Open3D object | Open3D 0.19 | visualization/processing clients | external adapter; time stays in Open4D |
+| `integrations/unity` | decodes and plays TVMC-style subsequences in Unity/XR | zipped reference/basis/trajectory files | Unity meshes over time | C++, Eigen, C#, Unity | TVMC XR playback | isolated legacy/specialized consumer; needs disposition |
+| `apps` | intended home for complete vertical slices | shared APIs plus codec | documented application artifacts | component-dependent | end users/reviewers | scaffold until Draco app exists |
+| `scripts` | initializes Draco copies, fetches checked artifacts, reserves data setup | URLs/checksums/repo state | local dependencies/artifacts | shell, CMake, Git | setup and reproducibility | keep checksum and manifest policy; add validation |
+| `docs` | architecture, policies, onboarding | repository evidence | versioned guidance | none | all contributors | source of truth only when tied to revision/evidence |
+
+## Codec map
+
+| Codec | Basic idea | Native input | Native output | Where it aligns next |
+| --- | --- | --- | --- | --- |
+| Draco | quantize/predict one triangle mesh and entropy-code it | per-frame OBJ | `.drc`, decoded OBJ, evaluation files | first strict encode/decode `Sequence` vertical slice |
+| KLT | learn a PCA/KLT basis for TSDF blocks and quantize coefficients | TSDF `.npz` volumes | compressed coefficient intermediates and reconstructed mesh | package basis/mean and expose decoded meshes |
+| N4MC | neural latent representation of TSDF volumes, then marching cubes | meshes converted to TSDF or TSDF datasets | checkpoint/latent packs/reconstructed meshes | define complete artifact; adapt reconstructed mesh provider |
+| QNDF | coarse SSP mesh plus neural implicit displacement decoder | OBJ mesh | model/coarse mesh/reconstruction/metrics | package all decode dependencies; adapt result frames |
+| QNDF-INT8 | dynamic INT8 quantization experiment on QNDF linear layers | existing SSP pair | FP32/INT8 TorchScript and meshes | retain as bounded experiment, not general codec API |
+| TVMC | track a reference shape and compress temporal displacements | numbered OBJ sequence | reference/deformation/displacement artifacts and decoded OBJ | first temporal `Sequence` adapter; independent decode |
+| TSMC | split static/dynamic scene, track dynamic reference, compress motion | scene mesh sequence and SAM-derived masks | static/dynamic/reference/displacement results | reuse TVMC boundaries after shared side information exists |
+| V-DMC | MPEG reference test model for video-based dynamic mesh coding | test-model formats | standard bitstreams/decoded assets | initialize/build upstream, then add wrapper |
+
+See the [codec guide](codecs.md) for the beginner-level pipeline and limitations
+of each method.
+
+## Reconstruction and network map
+
+| Area | What it does | Native input | Native output | Where it aligns next |
+| --- | --- | --- | --- | --- |
+| `reconstruction/rgbd` Python | receives two synchronized RGB-D cameras, aligns point clouds, fuses CUDA TSDF meshes, serves Open3D WebRTC | OBP1 RGB JPEG + compressed depth, calibration | latest PLY point cloud/mesh and JSON report | finalized capture replay as finite changing-topology `Sequence` |
+| `reconstruction/rgbd` C++ | original camera/playback reconstruction and mesh transport | K4A-compatible camera or recording | PLY/OBJ/texture/Draco, MRD messages, stage metrics | keep as hardware/native lane; add protocol golden tests |
+| OBP1 | bounded, CRC-protected paired RGB-D input transport with ACK | compressed color/depth payloads and timing metadata | validated paired capture frames | preserve framing; test reconnect/gaps/duplicates and recording |
+| MRD1/MRD2 | one-shot raw or Draco mesh/texture transfer | reconstructed mesh and texture | one validated message | retain as fixtures/reference formats |
+| MRD3 | continuous Draco/JPEG mesh frames | successive reconstruction results | live frame messages and receive statistics | label experimental; supersede only after live contract |
+| QUEEN | trains and quantizes dynamic 3D Gaussians for free-viewpoint video | calibrated multi-view images/COLMAP | initial/delta Gaussian artifacts and rendered views | Ryan-owned handoff contract only |
+| 3DGStream | initial 3DGS plus per-frame neural transformation cache/new Gaussians | calibrated multi-view images and initial 3DGS | per-frame NTC/new Gaussian data and renders | Ryan-owned handoff contract only |
+| `gs_tools` | currently a one-heading placeholder | none | none | correct stale descriptions; do not resurrect deleted design |
+
+See [reconstruction and streaming](reconstruction-streaming.md) for data and
+protocol details.
+
+## Important root configuration
+
+- `pyproject.toml` advertises a NumPy-only base and optional `player`, `usd`,
+  `tools`, and `open3d` extras. Its current namespace auto-discovery is too broad
+  for a safe lightweight wheel and is a P0 item.
+- `environment.yml` plus `requirements-codecs.txt` define one Python 3.12 codec
+  environment; `.NET 10`, CMake, CUDA extensions, camera SDKs, and Unity remain
+  machine/toolchain concerns.
+- `.gitmodules` pins three Draco copies, QNDF's libigl, TSMC's SAM3, and MPEG
+  V-DMC. All were uninitialized in the audited checkout.
+- `.gitignore` now names expected local data/output locations, but large
+  historical artifacts are already tracked and need a provenance-preserving
+  migration.
+- `docs/artifacts.md` defines checksum and manifest expectations; it should be
+  treated as policy even before automated enforcement exists.
+
+## Where a new contribution belongs
+
+| Contribution | Preferred home |
+| --- | --- |
+| finite geometry/sequence invariant | `open4d/core` |
+| general supported file/container loader | future `open4d/io` |
+| general versioned metric | future `open4d/metrics` |
+| method-specific training/encoding code | its codec/reconstruction directory |
+| conversion to an external framework | `integrations/<framework>` |
+| complete reproducible user workflow | `apps/<workflow>` |
+| teaching, inspection, visualization | `examples/` |
+| durable architecture/policy | `docs/` plus tests where enforceable |
+
+Avoid adding another copy of mesh parsing, metric code, or directory ordering to
+a codec. First promote and test the shared behavior, then have the codec call it.

--- a/docs/handbook/v0.2-dev/roadmap.md
+++ b/docs/handbook/v0.2-dev/roadmap.md
@@ -1,0 +1,201 @@
+# Dependency-ordered roadmap and TODO list
+
+This list is ordered by dependency and risk, not by how exciting the demo looks.
+P0 prevents unsafe releases and false status claims; P1 creates reusable
+contracts; P2 proves them on a CPU codec; P3 applies them to temporal capture
+and compression.
+
+## Priority graph
+
+```mermaid
+flowchart LR
+    P0["P0: truth, safety, CI"] --> P1["P1: public platform"]
+    P1 --> P2["P2: Draco vertical slice"]
+    P2 --> TVMC["P3: TVMC adapter"]
+    P1 --> RGBD["P3: RGB-D replay"]
+    P1 --> Contract["P3: live contract"]
+    RGBD --> Contract
+    TVMC --> MoreCodecs["later codec fan-out"]
+    Contract --> ProdStream["later production streaming"]
+    Ryan["Ryan's Gaussian handoff"] -. "independent, reviewed" .-> FutureRepr["future representation expansion"]
+```
+
+## P0 — days 1–14: truth, safety, and enforceable quality
+
+### Critical release safety
+
+- [x] Publish this versioned `v0.2-dev` handbook and link it from the root
+  README.
+- [ ] Replace namespace auto-discovery with an explicit lightweight package
+  allowlist.
+- [ ] Build a clean wheel and assert its exact file list; ensure no research
+  codec, Gaussian, dataset, paper, or Unity binary ships accidentally.
+- [ ] Create a root third-party/provenance ledger covering code, submodules,
+  models, datasets, binaries, papers, copied helpers, and licenses.
+- [ ] Resolve TVMC, QNDF, copied-upstream, binary, and dataset distribution
+  scope. Block releases until this gate passes.
+- [ ] Record Ryan's ownership of QUEEN/3DGStream in contribution/ownership
+  guidance and exclude those paths from unrelated refactors.
+
+### CI and tests
+
+- [ ] Add Python 3.10–3.13 core build/install/import/test jobs.
+- [ ] Add Python 3.10–3.12 Open3D jobs.
+- [ ] Add clean packaging smoke tests and exact wheel-content checks.
+- [ ] Add Python syntax, shell syntax, Markdown-link, provenance, and license
+  validation.
+- [ ] Configure root pytest markers: `cpu`, `open3d`, `torch`, `gpu`,
+  `hardware`, and `slow`.
+- [ ] Keep research experiment scripts out of default test collection without
+  deleting their documented workflows.
+- [ ] Restore comprehensive Frame/provider/Sequence/view tests: empty,
+  timestamps, slices, topology, metadata, cleanup, laziness, failures.
+- [ ] Reject integer named attributes outside the canonical `int32` range.
+
+### P0 acceptance
+
+- A clean supported environment installs and runs one documented command.
+- The wheel contains only intentional MIT-compatible lightweight files.
+- Every green handbook claim maps to an automated command.
+- Default tests never open local datasets, absolute user paths, GPUs, or
+  hardware.
+- The repository/status map agrees with the actual tree.
+
+## P1 — days 15–35: establish the public platform
+
+### Public interfaces
+
+- [ ] Add `open4d.io.open_sequence(path, fps=None) -> Sequence`.
+- [ ] Add `open4d.io.write_usd_container(path, frames, ...) -> Path`.
+- [ ] Add `open4d.metrics.compare_meshes(...)`.
+- [ ] Add `open4d.metrics.compare_sequences(..., allow_truncate=False)`.
+- [ ] Keep the base NumPy-only and lazily load SciPy/OpenUSD/Open3D/viewers.
+- [ ] Convert examples into thin clients of the public functions.
+
+### Correctness and interchange
+
+- [ ] Require equal sequence lengths by default; make truncation explicit.
+- [ ] Pool sequence error/PSNR using one documented peak and retain source
+  frame indices.
+- [ ] Publish metric identifier `open4d.vertex-nearest/v1` and clearly label
+  vertex-set, non-area-weighted limitations.
+- [ ] Ratify OpenUSD schema v1 as primary offline interchange.
+- [ ] Round-trip positions, triangles, colors, normals, UVs, named attributes,
+  timestamps, frame indices, sequence metadata, and topology declarations.
+- [ ] Support Y-up/Z-up, reject X-up, reject mixed Mesh/Points, and handle empty
+  extents explicitly.
+- [ ] Add a generated or redistributable two-to-three-frame fixture.
+- [ ] Implement and validate `open4d.run-manifest/v1`.
+
+### P1 acceptance
+
+- Loader construction remains lazy and lifecycle cleanup is tested.
+- Every supported USD field round-trips; unsupported data fails explicitly.
+- The base wheel remains lightweight and contains no research codec.
+- One tiny fixture and manifest schema are reused by later adapters.
+
+## P2 — days 36–60: first complete Draco vertical slice
+
+- [ ] Deterministically initialize/build the pinned Draco implementation.
+- [ ] Create `apps/` reference workflow:
+
+  ```text
+  fixture -> open_sequence -> Draco encode -> retained artifact only
+          -> fresh-process decode -> lazy decoded Sequence
+          -> shared metrics -> manifest -> optional viewer
+  ```
+
+- [ ] Check subprocess return codes and surface command/stderr/actionable setup
+  errors.
+- [ ] Store every frame's source index, timestamp, codec configuration, hash,
+  and actual encoded bytes.
+- [ ] Decode after source and intermediates are inaccessible.
+- [ ] Separate codec payload, filesystem/container, and future wire bytes.
+- [ ] Add golden metric/size bounds and keep codec-local metrics alongside the
+  cross-codec baseline.
+- [ ] Run the same CPU vertical slice in CI with one documented command.
+
+### P2 acceptance
+
+- Recursive clone plus one command runs the CPU workflow.
+- Fresh decode requires only the declared artifact.
+- The result includes decoded sequence, comparison report, and valid manifest.
+- This becomes the first component eligible for `COMPLETE`.
+
+## P3 — days 61–90: temporal adapter, finite replay, live contract
+
+### TVMC temporal adapter
+
+- [ ] Consume the public directory `Sequence` without breaking current CLI,
+  files, cached intermediates, dry-run, or resume behavior.
+- [ ] Serialize every value needed to restore displacement-to-vertex
+  correspondence.
+- [ ] Prove decoding without original encoder-side displacement values.
+- [ ] Expose decoded frames through a finite lazy provider.
+- [ ] Declare changing/fixed topology, constant vertex count, and correspondence
+  at the stages where each statement is true.
+
+### RGB-D finite replay
+
+- [ ] Preserve pair/device/sender time, sync error, drop counters, calibration,
+  units, coordinate frame, backend, configuration, and reconstruction timing.
+- [ ] Add a tiny camera-free synthetic or licensed recorded fixture.
+- [ ] Convert mesh results to `Frame(TriangleMesh)` with changing topology.
+- [ ] Finalize/reopen a recording as a finite `Sequence` and write USD.
+- [ ] Add OBP1 golden tests for fragmentation, CRCs, bounds, malformed serials,
+  ACKs, gaps, duplicates, shutdown, reconnect, timestamps, and bounded queues.
+
+### Live-source architecture contract
+
+- [ ] Keep finite `Sequence` unchanged.
+- [ ] Specify future `LiveSource[T]`/`StreamSample[T]`: session, epoch, 64-bit
+  frame ID, clock/presentation time, dependency, type, buffer/drop policy,
+  statistics, cancellation/error/closure.
+- [ ] Define recording and frozen-snapshot conversion to finite providers.
+- [ ] Specify separate payload/wire/goodput/latency/startup/drop measurements.
+- [ ] Keep localhost plus SSH tunnel as the supported remote security model.
+- [ ] Mark MRD1/2 one-shot fixtures, MRD3 experimental, and raw Unity transport
+  deprecated.
+
+### P3 acceptance
+
+- TVMC independently decodes to a `Sequence`.
+- Camera-free replay deterministically produces mesh frames and USD.
+- OBP1 tests prove bounds, reconnect, timing preservation, and bounded memory.
+- Live-contract replay tests pass without weakening finite sequence semantics.
+
+## Post-90-day backlog
+
+1. **Finish self-contained codec artifacts**: KLT basis/mean and decoder; N4MC
+   real entropy/model accounting/SSIM contract; QNDF full decode bundle; TSMC
+   entropy side information; initialized V-DMC wrapper and macOS build work.
+2. **Fan out adapters**: reuse TVMC directory/reference machinery in TSMC;
+   expose N4MC/KLT reconstructed meshes before defining volumes; expose QNDF
+   frame/sequence-run outputs; require fresh-decode golden tests everywhere.
+3. **Decide Unity support**: repair ABI/naming/eviction/build/tests or label
+   legacy/prebuilt-only; keep generic/TSMC playback accurately scoped.
+4. **Externalize historical artifacts**: N4MC outputs, TSMC datasets,
+   3DGStream assets, and Unity archive, preserving license/provenance/checksums;
+   implement the reserved dataset registry.
+5. **Expand representations from evidence**: PointCloud plus transforms/units
+   first; Volume/TSDF after real adapter needs; Gaussian only through a
+   Ryan-reviewed contract. Never force these into `TriangleMesh`.
+6. **Build production streaming after the contract**: independent Draco frames,
+   then TVMC reference chunks; authenticated encryption, multi-client queues,
+   jitter buffering, reconnect-to-keyframe, Unity/browser clients, and rate
+   adaptation.
+
+## Parallel work lanes
+
+Within each priority, independent lanes can run concurrently:
+
+- release/package/provenance;
+- core tests and test collection;
+- public I/O/USD;
+- public metrics/manifests;
+- Draco fixture/app after the P1 boundary is stable;
+- RGB-D protocol tests/replay fixture;
+- Ryan-owned Gaussian handoff, independently reviewed.
+
+Do not parallelize by letting each codec invent its own loader, metric, manifest,
+or live envelope. That creates fast local progress and slow project integration.

--- a/docs/handbook/v0.2-dev/status.md
+++ b/docs/handbook/v0.2-dev/status.md
@@ -1,0 +1,504 @@
+# Component status and evidence
+
+## Audit basis
+
+| Field | Value |
+| --- | --- |
+| Audited commit | `96b8c7bbb48e2a8d231684639cfc57799ca6666d` (`origin/main` baseline) |
+| Audit date | 2026-08-13 |
+| Recorded test environment | Python 3.12 for the captured shared-platform runs |
+| Recorded automated evidence | 106 core/visualization tests passed; 5 Open3D adapter tests passed |
+| Submodule state inspected | all six root submodule paths uninitialized (`git submodule status` prefixed each with `-`) |
+| Checkout size observed | approximately 1.2 GB, including tracked historical research data/results/binaries |
+| Package state | lightweight install/build works, but namespace discovery and license scope are not release-safe |
+
+The recorded shared commands were:
+
+```bash
+python -m pip install -e .
+python -m pytest -q open4d/core/tests examples/visualization/tests
+# 106 passed on Python 3.12
+
+python -m pytest -q integrations/open3d/tests
+# 5 passed on Python 3.12 with Open3D installed
+```
+
+The codec, GPU, camera, C++, .NET, Unity, and V-DMC statuses below are based on
+source/configuration/artifact inspection unless explicitly stated. A paper,
+README, tracked output, or runnable-looking script is not recorded end-to-end
+verification.
+
+## Status rubric
+
+> **Complete means:** setup is reproducible, a licensed sample runs end to end,
+> automated tests pass, outputs are documented, and the component works through
+> its supported Open4D interface.
+
+| Status | Meaning |
+| --- | --- |
+| `COMPLETE` | Meets every part of the strict definition above. |
+| `VERIFIED-PARTIAL` | Tested behavior works, but the subsystem or shared integration is incomplete. |
+| `WORKING-ISOLATED` | Useful standalone research pipeline exists without shared integration. |
+| `EXPERIMENT-COMPLETE` | A narrow research question was completed, not a general codec/system. |
+| `EXTERNAL-UNVERIFIED` | Pinned upstream code is not currently validated in Open4D. |
+| `SCAFFOLD` | Placeholder, policy, or design exists without an implemented vertical slice. |
+| `OWNER-RYAN` | Gaussian-splat work owned by Ryan; shared work stops at agreed interfaces. |
+
+No major end-to-end Open4D pipeline is `COMPLETE` in this snapshot.
+
+## What to preserve and what to build
+
+| Section | Status | Preserve | Needs work |
+| --- | --- | --- | --- |
+| Core model | `VERIFIED-PARTIAL` | canonical dtypes and geometry/frame/provider/sequence separation | comprehensive lifecycle/topology/time tests; safe integer attributes |
+| Example I/O/USD/metrics/viewers | `VERIFIED-PARTIAL` | laziness, format registry, symmetric comparison, synchronized viewer | promote stable APIs; schema fidelity; strict lengths; pooled reports |
+| Torch/Open3D adapters | `VERIFIED-PARTIAL` | dependency isolation and existing conversion semantics | packaging/support tiers and complete optional tests |
+| Codecs | mostly `WORKING-ISOLATED` | scientific pipelines and codec-local evaluation | self-contained artifacts, providers, shared metrics/manifests |
+| RGB-D/networking | `WORKING-ISOLATED` | OBP1 framing/bounds/CRCs/ACK and bounded latest queues | golden tests, finite replay/provider, live contract |
+| Gaussian splats | `OWNER-RYAN` | imported research implementations and ownership | Ryan-reviewed reproducible handoff only |
+| Unity | `WORKING-ISOLATED` | specialized TVMC decoder/playback | support-or-legacy decision and tiny tests |
+| Apps | `SCAFFOLD` | intended location | first Draco vertical slice |
+| Packaging/licensing/CI | `SCAFFOLD` to `VERIFIED-PARTIAL` | NumPy-only intent and checksum policy | allowlist, provenance/license gate, CI matrix |
+
+```mermaid
+flowchart TB
+    Safe["preserve now"] --> Core["core dtype + value/provider layers"]
+    Safe --> Viewer["comparison viewer behavior"]
+    Safe --> Torch["tested Torch replacements"]
+    Safe --> TVMC["TVMC resumable stages"]
+    Safe --> OBP["OBP1 framing + bounded queues"]
+
+    Work["highest-priority work"] --> License["packaging/license boundary"]
+    Work --> CI["CI + comprehensive tests"]
+    Work --> API["public I/O + metric + USD contracts"]
+    API --> Draco["Draco complete vertical slice"]
+    Draco --> Temporal["TVMC temporal adapter"]
+    API --> Replay["RGB-D finite replay"]
+    Replay --> Live["live-source contract"]
+    Ryan["Ryan-owned QUEEN / 3DGStream"] -. "handoff only" .-> API
+```
+
+## Detailed register: shared platform
+
+### Core geometry, frame, provider, and sequence — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** NumPy-backed mesh values and a finite lazy
+  temporal abstraction with topology declarations.
+- **Open4D integration:** this is the current public root-package API and the
+  intended boundary for loaders, decoded outputs, metrics, and adapters.
+- **Verification:** included in the recorded 106-test Python 3.12
+  core/visualization run; source inspection shows most historical coverage is
+  concentrated in dtype tests at this revision.
+- **Input/output:** NumPy-compatible arrays/providers -> `TriangleMesh`,
+  `Frame`, `Sequence`, and lazy views.
+- **Owner lane:** shared platform.
+- **Known blockers:** incomplete Frame/provider/Sequence lifecycle, failure,
+  timestamp, topology, empty, and view tests; generic integer attributes can
+  narrow to `int32` without an explicit range guard.
+- **Smallest useful next contribution:** add the missing behavior tests and one
+  failing large-integer-attribute test before changing implementation.
+
+### Example mesh/folder loaders — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** lazy folders/single files for OBJ, PLY, USD,
+  and optional trimesh formats.
+- **Open4D integration:** returns the core `Sequence`, but the API lives under
+  `examples/visualization`, not `open4d.io`.
+- **Verification:** included in the recorded 106-test Python 3.12 run.
+- **Input/output:** mesh directory or file -> lazy `Sequence[Frame[TriangleMesh]]`.
+- **Owner lane:** shared platform I/O.
+- **Known blockers:** filename-last-number ordering trap, mixed-format skipping,
+  limited OBJ/PLY attributes, point-cloud placeholder, no supported public API.
+- **Smallest useful next contribution:** promote `open_sequence` with its
+  registry/providers to `open4d.io` behind parity and cleanup tests.
+
+### Example OpenUSD container — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** reads/writes time-sampled mesh or points
+  stages, topology keyframes, colors, timing streams, and layer metadata.
+- **Open4D integration:** example provider returns `Sequence`; writer consumes
+  frames, but no ratified public schema/API exists.
+- **Verification:** USD behavior is represented in visualization tests; exact
+  supported-field round-trip is not complete.
+- **Input/output:** frames or USD -> `.usd/.usda/.usdc/.usdz` or `Sequence`.
+- **Owner lane:** shared platform I/O/interchange.
+- **Known blockers:** normals/UVs/attributes/metadata fidelity, original index
+  restoration, mixed Mesh/Points handling, empty extent, and X-up validation.
+- **Smallest useful next contribution:** write schema-v1 golden tests for every
+  supported field plus explicit failure tests for mixed kinds/X-up.
+
+### Example comparison metrics — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** bidirectional nearest-vertex point and plane
+  distances, RMS, maximum/Hausdorff label, PSNR, error colors, CSV summaries.
+- **Open4D integration:** consumes core sequences in example code; not yet
+  `open4d.metrics` and no metric identifier/version.
+- **Verification:** included in the recorded 106-test Python 3.12 run.
+- **Input/output:** reference and decoded mesh sequences -> comparison objects,
+  console/CSV figures, per-vertex distances/colors.
+- **Owner lane:** shared metrics/evaluation.
+- **Known blockers:** truncates unequal lengths, arithmetic mean frame PSNR,
+  non-pooled sequence summary, lost source index, vertex-set scientific limits.
+- **Smallest useful next contribution:** make unequal lengths fail by default
+  and add pooled golden cases while preserving explicit truncation mode.
+
+### PyQt visualization and comparison — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** single/dual synchronized 3D playback, orbit,
+  scrub/step, error shading/colorbar, and GIF rendering.
+- **Open4D integration:** consumes core sequences through example loaders; not a
+  base dependency and not an end-to-end codec app.
+- **Verification:** non-window behavior is included in the 106-test run; GUI/GL
+  behavior requires manual graphical-session acceptance.
+- **Input/output:** `Sequence`/comparison -> interactive OpenGL window or GIF.
+- **Owner lane:** examples/visualization.
+- **Known blockers:** eager decode/measurement of displayed frames, graphical
+  environment, and no automated visual acceptance matrix.
+- **Smallest useful next contribution:** document and automate a tiny headless
+  render smoke test where the platform supports it without changing UI behavior.
+
+### Torch operations — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** local geometry-only OBJ I/O, normals,
+  sampling, Chamfer, and point-face functions replacing PyTorch3D call sites.
+- **Open4D integration:** used directly by N4MC/QNDF research code; intentionally
+  outside the NumPy-only core model.
+- **Verification:** dedicated Torch tests exist and the replacements were tested
+  during environment unification; they were not part of the captured 111-test
+  core/Open3D count.
+- **Input/output:** Torch tensors/OBJ -> tensors, mesh helper values, distances.
+- **Owner lane:** shared optional Torch utilities plus codec owners.
+- **Known blockers:** optional dependency/test-tier definition and GPU/CPU
+  compatibility coverage are not enforced by CI.
+- **Smallest useful next contribution:** add a marked CPU Torch CI tier that
+  exercises the existing tests against the pinned shared environment.
+
+### Open3D adapter — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** converts Open4D or compatible geometry to
+  Open3D triangle mesh or point cloud with colors/normals.
+- **Open4D integration:** external frame adapter; correctly does not own
+  sequence time/storage.
+- **Verification:** 5 tests passed on Python 3.12 with Open3D.
+- **Input/output:** geometry/frame-like arrays -> Open3D legacy geometry.
+- **Owner lane:** external integrations.
+- **Known blockers:** no Python 3.13 Open3D wheel; no UV/material conversion;
+  optional-tier CI absent.
+- **Smallest useful next contribution:** add the 3.10–3.12 Open3D CI job and
+  verify actionable missing-extra errors.
+
+### Applications directory — `SCAFFOLD`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** intended home for compression, XR, and
+  offline end-to-end workflows.
+- **Open4D integration:** none; it contains only a short README.
+- **Verification:** source inspection only; no application or test exists.
+- **Input/output:** not defined.
+- **Owner lane:** shared applications.
+- **Known blockers:** public I/O/metrics/manifest boundaries and reference app
+  are missing.
+- **Smallest useful next contribution:** after P1, add the tiny Draco vertical
+  slice with one documented command.
+
+## Detailed register: codecs
+
+### Draco baseline — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** pinned Google Draco encoder/decoder plus a
+  per-frame quantization sweep and codec-local evaluation.
+- **Open4D integration:** no `Sequence` input/output, artifact schema, shared
+  metric, or app; binary wrapper is standalone.
+- **Verification:** source/setup inspection; Draco submodule uninitialized, so
+  no audit-time encode/decode run.
+- **Input/output:** OBJ folder -> `.drc`, decoded OBJ, local metrics.
+- **Owner lane:** codec adapter/shared first vertical slice.
+- **Known blockers:** deterministic build/sample, fresh-process decoding,
+  timing/identity metadata, exact accounting, manifest/provider.
+- **Smallest useful next contribution:** create one licensed two-frame fixture
+  and a golden encode -> fresh decode subprocess test.
+
+### KLT — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** learns a KLT/PCA TSDF-block basis, quantizes
+  coefficients, reconstructs volume/mesh, and optionally evaluates it.
+- **Open4D integration:** standalone script over TSDF files; no provider or
+  complete encoded bundle.
+- **Verification:** source and documented operating-point inspection; no
+  end-to-end audit run.
+- **Input/output:** TSDF `.npz` -> coefficient/packing intermediates and
+  marching-cubes meshes.
+- **Owner lane:** codec research, later adapter.
+- **Known blockers:** basis/mean/shape/quantization state not packaged for an
+  independent decoder; high training-block memory.
+- **Smallest useful next contribution:** specify and test a bundle containing
+  basis, mean, volume/block metadata, and coefficient stream.
+
+### N4MC — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** legacy and modular neural TSDF codec paths,
+  training/validation, latent packs, marching-cubes reconstruction, basketball
+  runner, and codec-local metrics.
+- **Open4D integration:** no shared provider or codec contract; Torch/TSDF/local
+  mesh types dominate the research path.
+- **Verification:** tracked results and source/workflow inspection; no clean
+  GPU end-to-end audit run.
+- **Input/output:** meshes/TSDF datasets -> checkpoints, latents, reconstructed
+  normalized/restored meshes, JSON status/summary.
+- **Owner lane:** N4MC research, later shared adapter.
+- **Known blockers:** real entropy bitstream and complete decoder artifact/rate
+  accounting; SSIM contract; GPU extras; large tracked outputs.
+- **Smallest useful next contribution:** define the full decoder dependency
+  manifest and test a reconstructed-mesh provider without changing training.
+
+### QNDF — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** SSP coarse/subdivide/project preprocessing,
+  neural displacement training/quantization, disconnected-component path, and
+  resumable sequence runner.
+- **Open4D integration:** local scripts/OBJ and Torch operations; no shared
+  artifact or sequence output.
+- **Verification:** source inspection; pinned libigl uninitialized and no GPU
+  audit run.
+- **Input/output:** OBJ -> training pair, transform, model, reconstruction,
+  metrics/status.
+- **Owner lane:** QNDF research, later adapter.
+- **Known blockers:** GPL-3.0 distribution boundary; complete coarse mesh,
+  normalization, model/configuration, entropy bundle; no fresh decoder test.
+- **Smallest useful next contribution:** write a decode-dependency manifest for
+  one existing run and prove which undeclared files are still required.
+
+### QNDF-INT8 — `EXPERIMENT-COMPLETE`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** compares FP32 and dynamically quantized INT8
+  QNDF linear layers with reloadable TorchScript artifacts and quality/size data.
+- **Open4D integration:** intentionally isolated sibling experiment; no temporal
+  or shared codec API.
+- **Verification:** source/result-document inspection; the experiment includes
+  reload verification, but this audit did not reproduce training.
+- **Input/output:** existing SSP pair -> FP32/INT8 models, reconstructions,
+  `metrics.json`.
+- **Owner lane:** QNDF research experiment.
+- **Known blockers:** not a full QNDF artifact and not the abandoned/commented
+  Huffman format; depends on prepared sibling inputs.
+- **Smallest useful next contribution:** preserve the bounded result and add
+  provenance/hash fields rather than generalizing it prematurely.
+
+### TVMC — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** tracked reference/deformation/displacement
+  temporal compression with Python, .NET, Draco, resumable stages, cached work,
+  a basketball sample, and evaluation.
+- **Open4D integration:** numbered files and private config/state; no shared
+  input or decoded provider.
+- **Verification:** source and dry-run/resume design inspection; Draco submodule
+  uninitialized and no full .NET pipeline audit run.
+- **Input/output:** OBJ sequence/config -> centers/transforms/reference,
+  displacement/trajectory data, decoded OBJ, metrics.
+- **Owner lane:** TVMC research plus first temporal adapter.
+- **Known blockers:** restrictive non-commercial/no-redistribution license;
+  decoder dependence on encoder-side displacement/correspondence information;
+  mixed toolchains.
+- **Smallest useful next contribution:** serialize the missing correspondence
+  side information and prove decode with original displacement values hidden.
+
+### TSMC — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** SAM3 static/dynamic separation, tracking,
+  reference deformation, displacement compression, scene evaluation, paper data.
+- **Open4D integration:** standalone imported pipeline with duplicate TVMC-like
+  conversions; no shared sequence/codec contract.
+- **Verification:** source and tracked-paper-artifact inspection; Draco/SAM3
+  submodules uninitialized and no Ubuntu/GPU/.NET audit run.
+- **Input/output:** scene mesh/image data -> static/dynamic meshes, tracking,
+  reference/displacement artifacts, reconstructed scenes/metrics.
+- **Owner lane:** TSMC research, adapter after TVMC.
+- **Known blockers:** entropy/decoder side information not self-contained,
+  heavy toolchain/data, licensing/provenance inventory, no integrated VR player.
+- **Smallest useful next contribution:** inventory the exact files required by
+  current decode/evaluation and mark which are encoder originals.
+
+### MPEG V-DMC test model — `EXTERNAL-UNVERIFIED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** MPEG dynamic-mesh reference encoder,
+  decoder, tools, metrics, and upstream tests.
+- **Open4D integration:** none beyond a pinned submodule path.
+- **Verification:** submodule pinned at `ecffe421...` but uninitialized; no
+  source/build/runtime inspection in this checkout.
+- **Input/output:** upstream test-model formats and bitstreams (not audited
+  locally).
+- **Owner lane:** standards/reference-codec integration.
+- **Known blockers:** initialize/build requirements, macOS build issue tracked
+  by the project, fixture/license/provenance, wrapper/provider/manifest.
+- **Smallest useful next contribution:** initialize the exact pin and record a
+  clean upstream build/test report before writing any Open4D wrapper.
+
+## Detailed register: reconstruction, network, and integrations
+
+### RGB-D reconstruction — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** synchronized two-camera capture receive,
+  calibrated point-cloud fusion, CUDA TSDF reconstruction/mesh merge, WebRTC
+  view, saved replay, plus a native C++ path.
+- **Open4D integration:** returns Open3D/live result objects and files; no core
+  `FrameProvider` or finalized finite sequence.
+- **Verification:** source/configuration inspection; camera, CUDA Open3D, and C++
+  pipelines not reproduced in the audit.
+- **Input/output:** OBP1/saved RGB-D/calibration or K4A source -> live cloud,
+  PLY mesh/cloud, reports, native OBJ/texture/Draco.
+- **Owner lane:** RGB-D reconstruction and shared replay boundary.
+- **Known blockers:** hardware/external sender/calibration, no tiny licensed
+  deterministic fixture, metadata not carried into core frames, stitching gap.
+- **Smallest useful next contribution:** create a tiny synthetic/saved pair and
+  convert its deterministic mesh result to a changing-topology frame.
+
+### OBP1 and MRD transports — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** bounded CRC/ACK paired RGB-D framing and
+  three mesh/texture transport experiments with reference receivers.
+- **Open4D integration:** private reconstruction protocols; no general live
+  source/envelope or finite recording adapter.
+- **Verification:** protocol source inspection; no captured binary/socket test
+  suite at the audit baseline.
+- **Input/output:** compressed capture or mesh/image payloads -> received
+  protocol records and statistics.
+- **Owner lane:** reconstruction networking/shared live-contract design.
+- **Known blockers:** fragmentation/corruption/reconnect/gap/duplicate tests,
+  session/epoch/dependency semantics, security beyond local SSH tunnel.
+- **Smallest useful next contribution:** add pure local `socketpair` OBP1 golden
+  tests for fragmentation, CRCs, declared bounds, ACK, and metadata.
+
+### Unity TVMC integration — `WORKING-ISOLATED`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** C++ reference/basis/trajectory decoder,
+  asynchronous windowed playback, C# Unity mesh updates, prebuilt macOS/Quest
+  libraries, encoded example.
+- **Open4D integration:** TVMC-specific files and ABI; no core `Sequence` or
+  generic codec/live contract.
+- **Verification:** source/binary/example inspection; Unity/Quest and source
+  rebuild not reproduced.
+- **Input/output:** zipped subsequences/reference/basis/trajectory binaries ->
+  decoded Unity meshes.
+- **Owner lane:** external integration, pending support decision.
+- **Known blockers:** source/prebuilt ABI, class/file naming, eviction behavior,
+  build matrix, restrictive TVMC boundary, no tiny automated test.
+- **Smallest useful next contribution:** document and test whether the checked-in
+  example decodes with each prebuilt plugin before choosing support vs legacy.
+
+### QUEEN — `OWNER-RYAN`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** quantized dynamic 3D Gaussian training,
+  compressed rendering/evaluation, and claimed streamable free-viewpoint video.
+- **Open4D integration:** vendored sibling reconstruction tree; no shared
+  representation, manifest, or verified adapter.
+- **Verification:** source/paper README/license inspection only; no GPU run.
+- **Input/output:** calibrated multi-view images/COLMAP/weights -> Gaussian
+  models/deltas, compressed artifacts, renders, metrics.
+- **Owner lane:** Ryan exclusively for algorithms, CUDA, environment,
+  representation, upstream decisions, correctness/performance.
+- **Known blockers:** exact upstream/local patch provenance, restrictive
+  NVIDIA/non-commercial terms, large dependencies, smoke artifact and handoff.
+- **Smallest useful next contribution:** shared team asks Ryan for the defined
+  input/output manifest and two-frame smoke contract; do not edit the tree.
+
+### 3DGStream — `OWNER-RYAN`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** initial 3D Gaussian model plus per-frame
+  neural transformation cache/additional Gaussians and specialized evaluation.
+- **Open4D integration:** vendored sibling reconstruction tree; no shared
+  representation, manifest, or verified adapter.
+- **Verification:** source/upstream README/license/tracked-fixture inspection;
+  no GPU/tiny-cuda-nn run.
+- **Input/output:** calibrated multi-view frames, COLMAP, initial 3DGS, NTC
+  config -> per-frame transformations/new Gaussians, renders, metrics.
+- **Owner lane:** Ryan under the same exclusive boundary as QUEEN.
+- **Known blockers:** upstream/local patch provenance, CUDA/tiny-cuda-nn setup,
+  large tracked assets, delta/keyframe/renderer contract.
+- **Smallest useful next contribution:** shared team requests Ryan's exact
+  upstream revision and renderer-ready artifact/dependency description.
+
+### `gs_tools` placeholder — `SCAFFOLD`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** none in this directory; it contains only the
+  heading `# gs-tools`.
+- **Open4D integration:** none.
+- **Verification:** direct source inspection.
+- **Input/output:** none.
+- **Owner lane:** documentation/shared coordination with Ryan.
+- **Known blockers:** stale documents incorrectly describe this as the parent of
+  QUEEN/3DGStream; previous deleted architecture is not approved.
+- **Smallest useful next contribution:** correct references to the actual
+  sibling directories; do not add code without Ryan's design review.
+
+## Detailed register: project operations
+
+### Packaging and release boundary — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** setuptools build with NumPy-only base and
+  optional player/USD/tools/Open3D extras.
+- **Open4D integration:** root distribution currently uses namespace package
+  auto-discovery (`open4d*`, `integrations*`).
+- **Verification:** package build/install was recorded working; built/local tree
+  inspection shows research namespace packages can be discovered beyond the
+  intended lightweight core.
+- **Input/output:** source tree -> wheel/editable installation.
+- **Owner lane:** shared release engineering.
+- **Known blockers:** exact wheel allowlist absent; root MIT metadata does not
+  represent GPL, non-commercial, no-redistribution, binaries, or datasets that
+  may enter distribution; no release gate.
+- **Smallest useful next contribution:** replace discovery with an explicit
+  allowlist and assert the exact wheel file set in a clean build test.
+
+### Artifact policy and fetch helper — `VERIFIED-PARTIAL`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** documented ignored runtime locations,
+  checksum-based fetch helper, and publication-manifest expectations.
+- **Open4D integration:** policy exists, but no root registry/schema validator
+  or enforcement covers historical tracked artifacts.
+- **Verification:** source/policy inspection; checkout observed around 1.2 GB.
+- **Input/output:** URL + SHA-256 -> verified local artifact; run metadata ->
+  proposed manifest.
+- **Owner lane:** shared reproducibility/release engineering.
+- **Known blockers:** tracked N4MC results, TSMC datasets, 3DGStream assets,
+  Unity archive, provenance/license records, external durable storage.
+- **Smallest useful next contribution:** inventory the largest tracked artifacts
+  with origin, license, consumer, checksum, and proposed storage location.
+
+### Continuous integration and support tiers — `SCAFFOLD`
+
+- **Audit:** `96b8c7b`, 2026-08-13.
+- **Research/upstream capability:** package metadata names Python support and
+  codec environment files name dependencies.
+- **Open4D integration:** no `.github` CI workflow, root test-tier markers, or
+  automated definition of done at this revision.
+- **Verification:** repository/configuration inspection.
+- **Input/output:** not implemented; intended commits -> matrix results/release
+  gates.
+- **Owner lane:** shared quality/release engineering.
+- **Known blockers:** test collection includes research-style filenames and
+  optional/hardware/GPU/manual tiers are not separated.
+- **Smallest useful next contribution:** add CPU build/install/import/core tests
+  for Python 3.10–3.13, then add marked optional jobs separately.

--- a/examples/visualization/tests/test_compare.py
+++ b/examples/visualization/tests/test_compare.py
@@ -26,6 +26,8 @@ import mesh_metrics
 from open4d import Frame, MemoryFrameProvider, Sequence, TriangleMesh
 from render_frames import UP_TO_Z
 
+pytestmark = pytest.mark.cpu
+
 
 # ----------------------------
 # Fixtures and helpers

--- a/integrations/open3d/tests/test_open4d_open3d.py
+++ b/integrations/open3d/tests/test_open4d_open3d.py
@@ -4,6 +4,8 @@ import numpy as np
 import open3d as o3d
 import pytest
 
+pytestmark = pytest.mark.open3d
+
 from integrations.open3d import frame_to_open3d
 
 

--- a/open4d/core/dtypes.py
+++ b/open4d/core/dtypes.py
@@ -140,11 +140,19 @@ def as_colors(array: NDArray, name: str = "colors") -> NDArray:
 
 
 def as_attribute(array: NDArray, name: str) -> NDArray:
-    """Return a named attribute in canonical storage for its kind.
-
-    Booleans are left alone — a mask is not a narrow integer — while integers and
-    floats are widened or narrowed to one width each, so an attribute name means
-    the same thing whichever codec wrote it.
+    """
+    Convert a named attribute to its canonical storage dtype.
+    
+    Parameters:
+        array (NDArray): Attribute values with a boolean, integer, or floating-point dtype.
+        name (str): Attribute name used in validation errors.
+    
+    Returns:
+        NDArray: The attribute with booleans preserved, integers stored as int32, or floating-point values stored as float32.
+    
+    Raises:
+        ValueError: If an integer value is outside the int32 range.
+        TypeError: If the array does not have a boolean, integer, or floating-point dtype.
     """
     if array.dtype == np.bool_:
         return array

--- a/open4d/core/dtypes.py
+++ b/open4d/core/dtypes.py
@@ -149,6 +149,14 @@ def as_attribute(array: NDArray, name: str) -> NDArray:
     if array.dtype == np.bool_:
         return array
     if np.issubdtype(array.dtype, np.integer):
+        bounds = np.iinfo(ATTRIBUTE_INT_DTYPE)
+        if array.size and (
+            int(array.min()) < bounds.min or int(array.max()) > bounds.max
+        ):
+            raise ValueError(
+                f"{name} holds values outside the range supported by "
+                f"{ATTRIBUTE_INT_DTYPE.name}"
+            )
         return array.astype(ATTRIBUTE_INT_DTYPE, copy=False)
     if np.issubdtype(array.dtype, np.floating):
         return _cast(array, ATTRIBUTE_FLOAT_DTYPE, name)

--- a/open4d/core/frame.py
+++ b/open4d/core/frame.py
@@ -21,6 +21,13 @@ class Frame:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """
+        Validate and normalize the frame fields after initialization.
+        
+        Raises:
+            TypeError: If a field has an invalid type.
+            ValueError: If the frame index is negative or the timestamp is not finite.
+        """
         if not isinstance(self.frame_index, Integral) or isinstance(
             self.frame_index, bool
         ):

--- a/open4d/core/frame.py
+++ b/open4d/core/frame.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from numbers import Real
+from numbers import Integral, Real
 from types import MappingProxyType
 from typing import Any, Mapping
 
@@ -21,7 +21,7 @@ class Frame:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.frame_index, int) or isinstance(
+        if not isinstance(self.frame_index, Integral) or isinstance(
             self.frame_index, bool
         ):
             raise TypeError("frame_index must be an integer")
@@ -37,5 +37,6 @@ class Frame:
         if not isinstance(self.metadata, Mapping):
             raise TypeError("metadata must be a mapping")
 
+        object.__setattr__(self, "frame_index", int(self.frame_index))
         object.__setattr__(self, "timestamp", timestamp)
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))

--- a/open4d/core/provider.py
+++ b/open4d/core/provider.py
@@ -77,9 +77,27 @@ class MemoryFrameProvider:
 
     @property
     def timestamps(self) -> tuple[float, ...]:
+        """Return the timestamps of all stored frames in frame order.
+        
+        Returns:
+        	tuple[float, ...]: The timestamp for each stored frame.
+        """
         return tuple(frame.timestamp for frame in self._frames)
 
     def get_frame(self, index: int) -> Frame:
+        """
+        Retrieve a frame by its nonnegative ordinal index.
+        
+        Parameters:
+            index (int): An integer-like frame index.
+        
+        Returns:
+            Frame: The frame at the specified index.
+        
+        Raises:
+            TypeError: If `index` is not integer-like.
+            IndexError: If `index` is negative or outside the available frame range.
+        """
         if isinstance(index, bool):
             raise TypeError("frame index must be an integer")
         try:

--- a/open4d/core/provider.py
+++ b/open4d/core/provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence as CollectionSequence
 from enum import Enum
+import operator
 from types import MappingProxyType
 from typing import Any, Mapping, Protocol, runtime_checkable
 
@@ -79,6 +80,12 @@ class MemoryFrameProvider:
         return tuple(frame.timestamp for frame in self._frames)
 
     def get_frame(self, index: int) -> Frame:
-        if index < 0 or index >= self.frame_count:
+        if isinstance(index, bool):
+            raise TypeError("frame index must be an integer")
+        try:
+            ordinal = operator.index(index)
+        except TypeError as exc:
+            raise TypeError("frame index must be an integer") from exc
+        if ordinal < 0 or ordinal >= self.frame_count:
             raise IndexError("frame index out of range")
-        return self._frames[index]
+        return self._frames[ordinal]

--- a/open4d/core/sequence.py
+++ b/open4d/core/sequence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import operator
 from collections.abc import Iterator
+from numbers import Integral, Real
 from types import MappingProxyType
 from typing import Any, Mapping, overload
 
@@ -19,11 +20,12 @@ class Sequence:
         if not isinstance(provider, FrameProvider):
             raise TypeError("provider must implement FrameProvider")
         count = provider.frame_count
-        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        if not isinstance(count, Integral) or isinstance(count, bool) or count < 0:
             raise ValueError("provider.frame_count must be a nonnegative integer")
         self._provider = provider
-        self._frame_count = count
+        self._frame_count = int(count)
         self._timestamps_cache: tuple[float, ...] | None = None
+        self._closed = False
 
         metadata = getattr(provider, "metadata", {})
         if not isinstance(metadata, Mapping):
@@ -51,6 +53,8 @@ class Sequence:
     def __getitem__(self, index: int | slice) -> Frame | "SequenceView":
         if isinstance(index, slice):
             return SequenceView(self, range(len(self))[index])
+        if isinstance(index, bool):
+            raise TypeError("sequence indices must be integers or slices")
         try:
             ordinal = operator.index(index)
         except TypeError as exc:
@@ -84,12 +88,24 @@ class Sequence:
             values = provided if provided is not None else (
                 self[index].timestamp for index in range(len(self))
             )
-            timestamps = tuple(float(value) for value in values)
+            normalized: list[float] = []
+            for value in values:
+                if not isinstance(value, Real) or isinstance(value, bool):
+                    raise TypeError("provider timestamps must be real numbers")
+                normalized.append(float(value))
+            timestamps = tuple(normalized)
             if len(timestamps) != len(self):
                 raise ValueError("provider timestamps length does not match frame_count")
             if any(not math.isfinite(value) for value in timestamps):
                 raise ValueError("provider timestamps must be finite")
-            if any(a > b for a, b in zip(timestamps, timestamps[1:])):
+            allow_nonmonotonic = getattr(
+                self._provider, "allow_nonmonotonic_timestamps", False
+            )
+            if not isinstance(allow_nonmonotonic, bool):
+                raise TypeError("provider allow_nonmonotonic_timestamps must be bool")
+            if not allow_nonmonotonic and any(
+                a > b for a, b in zip(timestamps, timestamps[1:])
+            ):
                 raise ValueError("sequence timestamps must be nondecreasing")
             self._timestamps_cache = timestamps
         return self._timestamps_cache
@@ -97,7 +113,7 @@ class Sequence:
     @property
     def duration(self) -> float:
         timestamps = self.timestamps
-        return timestamps[-1] - timestamps[0] if len(timestamps) > 1 else 0.0
+        return abs(timestamps[-1] - timestamps[0]) if len(timestamps) > 1 else 0.0
 
     @property
     def fps(self) -> float | None:
@@ -134,9 +150,14 @@ class Sequence:
 
     def close(self) -> None:
         """Close provider resources when the provider supports it."""
+        if self._closed:
+            return
         close = getattr(self._provider, "close", None)
         if close is not None:
+            if not callable(close):
+                raise TypeError("provider close must be callable")
             close()
+        self._closed = True
 
     def __enter__(self) -> "Sequence":
         return self
@@ -153,6 +174,7 @@ class _ViewProvider:
         self.topology = parent.topology
         self.has_constant_vertex_count = parent.has_constant_vertex_count
         self.has_vertex_correspondence = parent.has_vertex_correspondence
+        self.allow_nonmonotonic_timestamps = True
 
     @property
     def frame_count(self) -> int:
@@ -160,7 +182,7 @@ class _ViewProvider:
 
     @property
     def timestamps(self) -> tuple[float, ...]:
-        return tuple(self.parent[index].timestamp for index in self.indices)
+        return tuple(self.parent.timestamps[index] for index in self.indices)
 
     def get_frame(self, index: int) -> Frame:
         return self.parent[self.indices[index]]

--- a/open4d/core/sequence.py
+++ b/open4d/core/sequence.py
@@ -17,6 +17,12 @@ class Sequence:
     """A lazy, random-access temporal geometry sequence."""
 
     def __init__(self, provider: FrameProvider) -> None:
+        """
+        Initialize a sequence from a frame provider.
+        
+        Parameters:
+            provider (FrameProvider): Provider supplying the sequence frames, metadata, and topology.
+        """
         if not isinstance(provider, FrameProvider):
             raise TypeError("provider must implement FrameProvider")
         count = provider.frame_count
@@ -51,6 +57,19 @@ class Sequence:
     def __getitem__(self, index: slice) -> "SequenceView": ...
 
     def __getitem__(self, index: int | slice) -> Frame | "SequenceView":
+        """
+        Retrieve a frame by ordinal index or create a view for a slice.
+        
+        Parameters:
+            index (int | slice): The frame index or slice of frame indices.
+        
+        Returns:
+            Frame | SequenceView: The selected frame or a view containing the selected frames.
+        
+        Raises:
+            TypeError: If `index` is not an integer or slice, or if the provider returns an invalid frame.
+            IndexError: If an integer index is outside the sequence bounds.
+        """
         if isinstance(index, slice):
             return SequenceView(self, range(len(self))[index])
         if isinstance(index, bool):
@@ -82,7 +101,16 @@ class Sequence:
 
     @property
     def timestamps(self) -> tuple[float, ...]:
-        """Return ordered timestamps, decoding frames only if required."""
+        """
+        Provide the sequence timestamps, validating and caching them on first access.
+        
+        Returns:
+        	tuple[float, ...]: Finite timestamp values for the sequence.
+        
+        Raises:
+        	TypeError: If timestamps or the provider's monotonicity setting have an invalid type.
+        	ValueError: If timestamps have an invalid length, contain non-finite values, or decrease when nonmonotonic timestamps are disallowed.
+        """
         if self._timestamps_cache is None:
             provided = getattr(self._provider, "timestamps", None)
             values = provided if provided is not None else (
@@ -112,11 +140,22 @@ class Sequence:
 
     @property
     def duration(self) -> float:
+        """
+        Calculate the elapsed time between the first and last timestamps.
+        
+        Returns:
+        	float: The absolute difference between the first and last timestamps, or 0.0 for a sequence with fewer than two timestamps.
+        """
         timestamps = self.timestamps
         return abs(timestamps[-1] - timestamps[0]) if len(timestamps) > 1 else 0.0
 
     @property
     def fps(self) -> float | None:
+        """Compute the average frame rate from the sequence duration.
+        
+        Returns:
+        	float | None: The frames per second, or `None` when the sequence has fewer than two frames or no positive duration.
+        """
         duration = self.duration
         return (len(self) - 1) / duration if len(self) > 1 and duration > 0 else None
 
@@ -149,7 +188,12 @@ class Sequence:
         return self._optional_provider_flag("has_vertex_correspondence")
 
     def close(self) -> None:
-        """Close provider resources when the provider supports it."""
+        """
+        Close the sequence's provider resources once.
+        
+        Raises:
+        	TypeError: If the provider defines a non-callable `close` attribute.
+        """
         if self._closed:
             return
         close = getattr(self._provider, "close", None)
@@ -160,6 +204,7 @@ class Sequence:
         self._closed = True
 
     def __enter__(self) -> "Sequence":
+        """Enter the sequence's context-manager scope and return the sequence."""
         return self
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
@@ -168,6 +213,12 @@ class Sequence:
 
 class _ViewProvider:
     def __init__(self, parent: Sequence, indices: range) -> None:
+        """Initialize a sequence view over selected indices of a parent sequence.
+        
+        Parameters:
+        	parent (Sequence): The sequence providing the view's data and metadata.
+        	indices (range): The parent sequence indices included in the view.
+        """
         self.parent = parent
         self.indices = indices
         self.metadata = parent.metadata
@@ -182,9 +233,23 @@ class _ViewProvider:
 
     @property
     def timestamps(self) -> tuple[float, ...]:
+        """Return the timestamps corresponding to the selected frames.
+        
+        Returns:
+            tuple[float, ...]: The selected frame timestamps in view order.
+        """
         return tuple(self.parent.timestamps[index] for index in self.indices)
 
     def get_frame(self, index: int) -> Frame:
+        """
+        Retrieve a frame by its ordinal index within the view.
+        
+        Parameters:
+        	index (int): Ordinal index of the frame in the view.
+        
+        Returns:
+        	Frame: The frame at the specified view index.
+        """
         return self.parent[self.indices[index]]
 
 

--- a/open4d/core/tests/test_dtypes.py
+++ b/open4d/core/tests/test_dtypes.py
@@ -37,6 +37,8 @@ INTEGER_DTYPES = [
     np.int32, np.uint32, np.int64, np.uint64,
 ]
 
+pytestmark = pytest.mark.cpu
+
 
 # ----------------------------
 # Storage is canonical whatever the producer used
@@ -77,6 +79,16 @@ def test_attributes_are_narrowed_by_kind_and_masks_stay_boolean():
     assert mesh.attributes["curvature"].dtype == np.float32
     assert mesh.attributes["label"].dtype == np.int32
     assert mesh.attributes["selected"].dtype == np.bool_
+
+
+@pytest.mark.parametrize(
+    "value",
+    [np.iinfo(np.int32).min - 1, np.iinfo(np.int32).max + 1],
+)
+def test_integer_attributes_reject_values_that_would_overflow_int32(value):
+    labels = np.full(len(POSITIONS), value, dtype=np.int64)
+    with pytest.raises(ValueError, match="outside the range"):
+        TriangleMesh(POSITIONS, TRIANGLES, attributes={"label": labels})
 
 
 # ----------------------------

--- a/open4d/core/tests/test_dtypes.py
+++ b/open4d/core/tests/test_dtypes.py
@@ -91,6 +91,33 @@ def test_integer_attributes_reject_values_that_would_overflow_int32(value):
         TriangleMesh(POSITIONS, TRIANGLES, attributes={"label": labels})
 
 
+def test_integer_attributes_accept_int32_bounds():
+    """int32 min and max are accepted and stored as int32."""
+    min_val = np.iinfo(np.int32).min
+    max_val = np.iinfo(np.int32).max
+    mesh = TriangleMesh(
+        POSITIONS, TRIANGLES,
+        attributes={
+            "min_attr": np.full(len(POSITIONS), min_val, dtype=np.int32),
+            "max_attr": np.full(len(POSITIONS), max_val, dtype=np.int32),
+        },
+    )
+    assert mesh.attributes["min_attr"].dtype == np.int32
+    assert mesh.attributes["max_attr"].dtype == np.int32
+    assert mesh.attributes["min_attr"][0] == min_val
+    assert mesh.attributes["max_attr"][0] == max_val
+
+
+def test_empty_integer_attributes_are_accepted():
+    """Empty integer attributes should not fail validation."""
+    mesh = TriangleMesh(
+        POSITIONS, TRIANGLES,
+        attributes={"empty_int": np.array([], dtype=np.int64)},
+    )
+    assert mesh.attributes["empty_int"].dtype == np.int32
+    assert len(mesh.attributes["empty_int"]) == 0
+
+
 # ----------------------------
 # The two color conventions land in the same place
 # ----------------------------

--- a/open4d/core/tests/test_temporal.py
+++ b/open4d/core/tests/test_temporal.py
@@ -1,0 +1,343 @@
+"""Contract tests for frames, providers, sequences, views, and cleanup."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+from open4d import Frame, MemoryFrameProvider, Sequence, TopologyMode, TriangleMesh
+
+pytestmark = pytest.mark.cpu
+
+
+def mesh(offset: float = 0.0) -> TriangleMesh:
+    return TriangleMesh(
+        np.asarray([[offset, 0, 0], [offset, 1, 0], [offset, 0, 1]], dtype=np.float32),
+        np.asarray([[0, 1, 2]], dtype=np.uint32),
+    )
+
+
+def frames(count: int = 4) -> list[Frame]:
+    return [Frame(10 + index, index * 0.25, mesh(index), {"ordinal": index}) for index in range(count)]
+
+
+@pytest.mark.parametrize("value", [-1, -100])
+def test_frame_rejects_negative_indices(value):
+    with pytest.raises(ValueError, match="nonnegative"):
+        Frame(value, 0.0, mesh())
+
+
+@pytest.mark.parametrize("value", [True, 1.5, "1", None])
+def test_frame_rejects_non_integer_indices(value):
+    with pytest.raises(TypeError, match="integer"):
+        Frame(value, 0.0, mesh())
+
+
+def test_frame_accepts_numpy_integer_and_normalizes_it():
+    frame = Frame(np.int64(8), np.float32(0.5), mesh())
+    assert frame.frame_index == 8
+    assert type(frame.frame_index) is int
+    assert frame.timestamp == pytest.approx(0.5)
+    assert type(frame.timestamp) is float
+
+
+@pytest.mark.parametrize("value", [True, "0", None])
+def test_frame_rejects_non_real_timestamps(value):
+    with pytest.raises(TypeError, match="real"):
+        Frame(0, value, mesh())
+
+
+@pytest.mark.parametrize("value", [np.nan, np.inf, -np.inf])
+def test_frame_rejects_nonfinite_timestamps(value):
+    with pytest.raises(ValueError, match="finite"):
+        Frame(0, value, mesh())
+
+
+def test_frame_requires_geometry_and_mapping_metadata():
+    with pytest.raises(TypeError, match="TriangleMesh"):
+        Frame(0, 0.0, object())
+    with pytest.raises(TypeError, match="mapping"):
+        Frame(0, 0.0, mesh(), [])
+
+
+def test_frame_metadata_is_a_read_only_snapshot():
+    source = {"capture": "left"}
+    frame = Frame(0, 0.0, mesh(), source)
+    source["capture"] = "right"
+    assert isinstance(frame.metadata, MappingProxyType)
+    assert frame.metadata["capture"] == "left"
+    with pytest.raises(TypeError):
+        frame.metadata["new"] = 1
+
+
+def test_memory_provider_validates_inputs_and_snapshots_frames():
+    source = frames(2)
+    provider = MemoryFrameProvider(source, metadata={"name": "tiny"})
+    source.clear()
+    assert provider.frame_count == 2
+    assert provider.timestamps == (0.0, 0.25)
+    assert provider.metadata == {"name": "tiny"}
+    with pytest.raises(TypeError, match="sequence"):
+        MemoryFrameProvider(iter(frames()))
+    with pytest.raises(TypeError, match="Frame"):
+        MemoryFrameProvider([object()])
+    with pytest.raises(TypeError, match="TopologyMode"):
+        MemoryFrameProvider([], topology="fixed")
+
+
+@pytest.mark.parametrize("name", ["has_constant_vertex_count", "has_vertex_correspondence"])
+def test_memory_provider_rejects_invalid_optional_flags(name):
+    with pytest.raises(TypeError, match=name):
+        MemoryFrameProvider([], **{name: 1})
+
+
+def test_memory_provider_bounds_and_index_types():
+    provider = MemoryFrameProvider(frames(2))
+    assert provider.get_frame(0).frame_index == 10
+    for index in (-1, 2):
+        with pytest.raises(IndexError):
+            provider.get_frame(index)
+    with pytest.raises(TypeError, match="integer"):
+        provider.get_frame(True)
+
+
+class RecordingProvider:
+    def __init__(self, values=None, *, timestamps=None):
+        self.values = frames(5) if values is None else values
+        self.calls: list[int] = []
+        self.metadata = {"capture": "recording"}
+        self.topology = TopologyMode.CHANGING
+        if timestamps is not None:
+            self.timestamps = timestamps
+
+    @property
+    def frame_count(self):
+        return len(self.values)
+
+    def get_frame(self, index):
+        self.calls.append(index)
+        return self.values[index]
+
+
+def test_sequence_construction_is_lazy_and_metadata_is_snapshotted():
+    provider = RecordingProvider()
+    sequence = Sequence(provider)
+    assert provider.calls == []
+    provider.metadata["capture"] = "changed"
+    assert sequence.metadata == {"capture": "recording"}
+    assert sequence[1].frame_index == 11
+    assert provider.calls == [1]
+
+
+@pytest.mark.parametrize("count", [-1, True, 1.5])
+def test_sequence_rejects_invalid_provider_counts(count):
+    class Provider:
+        frame_count = count
+        def get_frame(self, index):
+            raise AssertionError
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        Sequence(Provider())
+
+
+def test_sequence_requires_provider_protocol_and_valid_declarations():
+    with pytest.raises(TypeError, match="FrameProvider"):
+        Sequence(object())
+    provider = RecordingProvider()
+    provider.metadata = []
+    with pytest.raises(TypeError, match="metadata"):
+        Sequence(provider)
+    provider = RecordingProvider()
+    provider.topology = "changing"
+    with pytest.raises(TypeError, match="topology"):
+        Sequence(provider)
+
+
+def test_sequence_integer_indexing_negative_index_and_bounds():
+    sequence = Sequence(RecordingProvider())
+    assert sequence[0].frame_index == 10
+    assert sequence[-1].frame_index == 14
+    assert sequence[np.int64(2)].frame_index == 12
+    for index in (-6, 5):
+        with pytest.raises(IndexError):
+            sequence[index]
+    for index in (True, 1.5, "1"):
+        with pytest.raises(TypeError, match="indices"):
+            sequence[index]
+
+
+def test_sequence_validates_provider_results_and_propagates_provider_errors():
+    provider = RecordingProvider([object()])
+    sequence = Sequence(provider)
+    with pytest.raises(TypeError, match="return a Frame"):
+        sequence[0]
+
+    marker = RuntimeError("decoder failed")
+    class FailingProvider:
+        frame_count = 1
+        def get_frame(self, index):
+            raise marker
+    with pytest.raises(RuntimeError) as caught:
+        Sequence(FailingProvider())[0]
+    assert caught.value is marker
+
+
+def test_iteration_decodes_in_ordinal_order():
+    provider = RecordingProvider()
+    assert [frame.frame_index for frame in Sequence(provider)] == [10, 11, 12, 13, 14]
+    assert provider.calls == [0, 1, 2, 3, 4]
+
+
+def test_provider_timestamps_avoid_frame_decoding_and_are_cached():
+    provider = RecordingProvider(timestamps=(0.0, 0.1, 0.2, 0.3, 0.4))
+    sequence = Sequence(provider)
+    assert sequence.timestamps == provider.timestamps
+    assert provider.calls == []
+    provider.timestamps = (99.0,) * 5
+    assert sequence.timestamps == (0.0, 0.1, 0.2, 0.3, 0.4)
+
+
+def test_timestamps_fall_back_to_frames_only_once():
+    provider = RecordingProvider()
+    sequence = Sequence(provider)
+    assert sequence.timestamps == (0.0, 0.25, 0.5, 0.75, 1.0)
+    assert provider.calls == [0, 1, 2, 3, 4]
+    assert sequence.timestamps == (0.0, 0.25, 0.5, 0.75, 1.0)
+    assert provider.calls == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.parametrize(
+    "timestamps, error, message",
+    [
+        ((0.0,), ValueError, "length"),
+        ((0.0, 0.2, 0.1, 0.3, 0.4), ValueError, "nondecreasing"),
+        ((0.0, 0.1, np.inf, 0.3, 0.4), ValueError, "finite"),
+        ((0.0, 0.1, True, 0.3, 0.4), TypeError, "real"),
+        ((0.0, 0.1, "0.2", 0.3, 0.4), TypeError, "real"),
+    ],
+)
+def test_sequence_rejects_invalid_provider_timestamps(timestamps, error, message):
+    with pytest.raises(error, match=message):
+        _ = Sequence(RecordingProvider(timestamps=timestamps)).timestamps
+
+
+def test_duration_and_average_fps_cover_empty_single_duplicate_and_regular_times():
+    assert Sequence(MemoryFrameProvider([])).duration == 0.0
+    assert Sequence(MemoryFrameProvider([])).fps is None
+    assert Sequence(MemoryFrameProvider(frames(1))).duration == 0.0
+    duplicate = [Frame(0, 1.0, mesh()), Frame(1, 1.0, mesh())]
+    assert Sequence(MemoryFrameProvider(duplicate)).fps is None
+    sequence = Sequence(RecordingProvider(timestamps=(1.0, 1.25, 1.5, 1.75, 2.0)))
+    assert sequence.duration == pytest.approx(1.0)
+    assert sequence.fps == pytest.approx(4.0)
+
+
+@pytest.mark.parametrize(
+    "mode, constant",
+    [(TopologyMode.FIXED, True), (TopologyMode.CHANGING, False), (TopologyMode.UNKNOWN, None)],
+)
+def test_topology_declarations(mode, constant):
+    provider = MemoryFrameProvider(frames(), topology=mode)
+    sequence = Sequence(provider)
+    assert sequence.topology is mode
+    assert sequence.has_constant_topology is constant
+
+
+def test_fixed_topology_implies_default_correspondence_flags_but_explicit_values_win():
+    fixed = Sequence(MemoryFrameProvider(frames(), topology=TopologyMode.FIXED))
+    assert fixed.has_constant_vertex_count is True
+    assert fixed.has_vertex_correspondence is True
+    explicit = Sequence(MemoryFrameProvider(
+        frames(), topology=TopologyMode.CHANGING,
+        has_constant_vertex_count=True, has_vertex_correspondence=False,
+    ))
+    assert explicit.has_constant_vertex_count is True
+    assert explicit.has_vertex_correspondence is False
+
+
+def test_invalid_optional_provider_flag_is_reported_when_consumed():
+    provider = RecordingProvider()
+    provider.has_vertex_correspondence = "yes"
+    sequence = Sequence(provider)
+    with pytest.raises(TypeError, match="has_vertex_correspondence"):
+        _ = sequence.has_vertex_correspondence
+
+
+def test_slices_are_lazy_views_and_preserve_source_identity():
+    provider = RecordingProvider(timestamps=(0.0, 0.25, 0.5, 0.75, 1.0))
+    sequence = Sequence(provider)
+    view = sequence[1:5:2]
+    assert len(view) == 2
+    assert provider.calls == []
+    assert [frame.frame_index for frame in view] == [11, 13]
+    assert provider.calls == [1, 3]
+    assert view.timestamps == (0.25, 0.75)
+    assert view.metadata == sequence.metadata
+    assert view.topology == sequence.topology
+
+
+def test_nested_and_reverse_views_map_indices_correctly():
+    sequence = Sequence(MemoryFrameProvider(frames()))
+    reverse = sequence[::-1]
+    assert [frame.frame_index for frame in reverse] == [13, 12, 11, 10]
+    assert reverse.timestamps == (0.75, 0.5, 0.25, 0.0)
+    assert reverse.duration == pytest.approx(0.75)
+    assert reverse.fps == pytest.approx(4.0)
+    assert [frame.frame_index for frame in sequence[1:][::2]] == [11, 13]
+
+
+def test_empty_view_has_zero_duration_and_no_fps():
+    view = Sequence(MemoryFrameProvider(frames()))[0:0]
+    assert len(view) == 0
+    assert view.timestamps == ()
+    assert view.duration == 0.0
+    assert view.fps is None
+
+
+def test_close_is_idempotent_and_context_manager_closes_on_errors():
+    class Provider(RecordingProvider):
+        def __init__(self):
+            super().__init__()
+            self.close_count = 0
+        def close(self):
+            self.close_count += 1
+    provider = Provider()
+    sequence = Sequence(provider)
+    with pytest.raises(RuntimeError, match="body"):
+        with sequence:
+            raise RuntimeError("body")
+    sequence.close()
+    assert provider.close_count == 1
+
+
+def test_failed_close_can_be_retried_and_noncallable_close_is_rejected():
+    class RetryProvider(RecordingProvider):
+        attempts = 0
+        def close(self):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise OSError("busy")
+    sequence = Sequence(RetryProvider())
+    with pytest.raises(OSError, match="busy"):
+        sequence.close()
+    sequence.close()
+    assert sequence._provider.attempts == 2
+
+    provider = RecordingProvider()
+    provider.close = "not callable"
+    with pytest.raises(TypeError, match="callable"):
+        Sequence(provider).close()
+
+
+def test_closing_a_view_does_not_close_its_parent():
+    class Provider(RecordingProvider):
+        closed = False
+        def close(self):
+            self.closed = True
+    provider = Provider()
+    parent = Sequence(provider)
+    parent[:2].close()
+    assert provider.closed is False
+    parent.close()
+    assert provider.closed is True

--- a/open4d/core/tests/test_temporal.py
+++ b/open4d/core/tests/test_temporal.py
@@ -13,6 +13,15 @@ pytestmark = pytest.mark.cpu
 
 
 def mesh(offset: float = 0.0) -> TriangleMesh:
+    """
+    Create a single-triangle mesh with an optional x-axis offset.
+    
+    Parameters:
+    	offset (float): Translation applied to the triangle's x coordinates.
+    
+    Returns:
+    	TriangleMesh: The constructed triangle mesh.
+    """
     return TriangleMesh(
         np.asarray([[offset, 0, 0], [offset, 1, 0], [offset, 0, 1]], dtype=np.float32),
         np.asarray([[0, 1, 2]], dtype=np.uint32),
@@ -20,6 +29,15 @@ def mesh(offset: float = 0.0) -> TriangleMesh:
 
 
 def frames(count: int = 4) -> list[Frame]:
+    """
+    Create a sequence of indexed frames with increasing timestamps and ordinal metadata.
+    
+    Parameters:
+    	count (int): The number of frames to create.
+    
+    Returns:
+    	list[Frame]: Frames with timestamps spaced 0.25 apart and meshes offset by index.
+    """
     return [Frame(10 + index, index * 0.25, mesh(index), {"ordinal": index}) for index in range(count)]
 
 
@@ -105,6 +123,13 @@ def test_memory_provider_bounds_and_index_types():
 
 class RecordingProvider:
     def __init__(self, values=None, *, timestamps=None):
+        """
+        Initialize a test frame provider with optional frame values and timestamps.
+        
+        Parameters:
+        	values: Frame values exposed by the provider; defaults to five generated frames.
+        	timestamps: Optional timestamps declared by the provider.
+        """
         self.values = frames(5) if values is None else values
         self.calls: list[int] = []
         self.metadata = {"capture": "recording"}
@@ -114,9 +139,11 @@ class RecordingProvider:
 
     @property
     def frame_count(self):
+        """Return the number of frames in the provider."""
         return len(self.values)
 
     def get_frame(self, index):
+        """Retrieve the frame associated with an index."""
         self.calls.append(index)
         return self.values[index]
 
@@ -334,6 +361,7 @@ def test_closing_a_view_does_not_close_its_parent():
     class Provider(RecordingProvider):
         closed = False
         def close(self):
+            """Mark the provider as closed."""
             self.closed = True
     provider = Provider()
     parent = Sequence(provider)

--- a/open4d/torch_ops/tests/test_io.py
+++ b/open4d/torch_ops/tests/test_io.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+pytestmark = pytest.mark.torch
+
 torch = pytest.importorskip("torch")
 
 from open4d.torch_ops import load_obj, save_obj  # noqa: E402

--- a/open4d/torch_ops/tests/test_mesh.py
+++ b/open4d/torch_ops/tests/test_mesh.py
@@ -13,6 +13,8 @@ import math
 
 import pytest
 
+pytestmark = pytest.mark.torch
+
 torch = pytest.importorskip("torch")
 
 from open4d.torch_ops import (  # noqa: E402

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,7 +12,8 @@ version = "0.1.0"
 # actually applies, in environment.yml, not here: pinning the core package to
 # 3.12 would stop `pip install open4d` on a 3.13 interpreter that can run it.
 requires-python = ">=3.10,<3.14"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 dependencies = ["numpy"]
 
 [project.optional-dependencies]
@@ -23,25 +24,31 @@ player = ["PyQt6", "pyqtgraph", "PyOpenGL", "pillow>=9", "scipy"]
 # cp313 wheel at all, so this extra is 3.12-and-below in practice.
 open3d = ["open3d>=0.19", "pillow>=9"]
 usd    = ["usd-core>=24.3"]
-all    = ["trimesh", "PyQt6", "pyqtgraph", "PyOpenGL", "open3d>=0.17", "pillow>=9", "usd-core>=24.3", "scipy"]
+torch  = ["torch"]
+dev    = ["build>=1.2", "pytest>=8", "scipy", "tomli>=2; python_version < '3.11'"]
+all    = ["trimesh", "PyQt6", "pyqtgraph", "PyOpenGL", "open3d>=0.19", "pillow>=9", "usd-core>=24.3", "scipy"]
 
 [tool.setuptools]
 include-package-data = false
+packages = [
+    "open4d",
+    "open4d.core",
+    "open4d.torch_ops",
+    "integrations",
+    "integrations.open3d",
+]
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["open4d*", "integrations*"]
-exclude = [
-    "data*",
-    "apps*",
-    # gs_tools is its own distribution (open4d-gs-tools) with its own CUDA
-    # extensions and a non-commercial license. It is not discoverable today --
-    # open4d/reconstruction/ has no __init__.py -- but installing the lightweight
-    # core must never start shipping a rasterizer if that changes.
-    "open4d.reconstruction*",
-    "cmake*",
-    "docker*",
-    "pc_frames*",
-    "integrations.open3d.tests*",
-    "open4d.core.tests*",
+[tool.pytest.ini_options]
+addopts = "-ra --strict-markers"
+testpaths = [
+    "open4d/core/tests",
+    "examples/visualization/tests",
+]
+markers = [
+    "cpu: deterministic tests that need no optional hardware",
+    "open3d: tests requiring the Open3D optional dependency",
+    "torch: tests requiring the Torch optional dependency",
+    "gpu: tests requiring a supported GPU stack",
+    "hardware: tests requiring cameras, XR devices, or other hardware",
+    "slow: tests excluded from quick feedback loops",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,9 @@ packages = [
 addopts = "-ra --strict-markers"
 testpaths = [
     "open4d/core/tests",
+    "open4d/torch_ops/tests",
     "examples/visualization/tests",
+    "integrations/open3d/tests",
 ]
 markers = [
     "cpu: deterministic tests that need no optional hardware",

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -15,6 +15,13 @@ REMOTE_SCHEMES = {"http", "https", "mailto", "data"}
 
 
 def markdown_files() -> list[Path]:
+    """
+    Collect the existing first-party Markdown files to validate.
+    
+    Returns:
+        list[Path]: Unique Markdown file paths in the designated repository locations,
+        sorted lexicographically.
+    """
     roots = [
         ROOT / name
         for name in (
@@ -39,6 +46,15 @@ def markdown_files() -> list[Path]:
 
 
 def main() -> int:
+    """
+    Validate local links in selected Markdown files.
+    
+    Reports invalid links to standard error and returns a failure status when any
+    absolute, out-of-repository, or missing local targets are found.
+    
+    Returns:
+    	int: 1 if validation errors are found, otherwise 0.
+    """
     errors: list[str] = []
     for document in markdown_files():
         text = document.read_text(encoding="utf-8")

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -12,6 +12,7 @@ from urllib.parse import unquote, urlsplit
 ROOT = Path(__file__).resolve().parents[1]
 LINK = re.compile(r"!?\[[^\]]*\]\((?P<target><[^>]+>|[^\s)]+)(?:\s+[^)]*)?\)")
 REMOTE_SCHEMES = {"http", "https", "mailto", "data"}
+HEADING = re.compile(r"^#{1,6}\s+(.+?)(?:\s*\{#([^}]+)\})?$", re.MULTILINE)
 
 
 def markdown_files() -> list[Path]:
@@ -38,21 +39,55 @@ def markdown_files() -> list[Path]:
     return sorted(set(files))
 
 
+def extract_heading_anchors(text: str) -> set[str]:
+    """Extract valid heading anchors from markdown text.
+
+    GitHub-style anchors are lowercase, replace spaces with hyphens,
+    and remove special characters except hyphens.
+    """
+    anchors = set()
+    for match in HEADING.finditer(text):
+        heading_text = match.group(1)
+        explicit_id = match.group(2)
+        if explicit_id:
+            anchors.add(explicit_id)
+        else:
+            # GitHub-style anchor generation
+            anchor = heading_text.lower()
+            anchor = re.sub(r"[^\w\s-]", "", anchor)
+            anchor = re.sub(r"[-\s]+", "-", anchor)
+            anchor = anchor.strip("-")
+            if anchor:
+                anchors.add(anchor)
+    return anchors
+
+
 def main() -> int:
     errors: list[str] = []
     for document in markdown_files():
         text = document.read_text(encoding="utf-8")
         for match in LINK.finditer(text):
             raw = match.group("target").strip("<>")
-            if raw.startswith("#"):
-                continue
             parsed = urlsplit(raw)
+            line = text.count("\n", 0, match.start()) + 1
+
+            # Handle in-page anchor links
+            if raw.startswith("#"):
+                fragment = parsed.fragment or raw[1:]
+                if fragment:
+                    anchors = extract_heading_anchors(text)
+                    if fragment not in anchors:
+                        errors.append(
+                            f"{document.relative_to(ROOT)}:{line}: "
+                            f"fragment not found in document: {raw}"
+                        )
+                continue
+
             if parsed.scheme.lower() in REMOTE_SCHEMES or parsed.netloc:
                 continue
             if not parsed.path:
                 continue
             target = Path(unquote(parsed.path))
-            line = text.count("\n", 0, match.start()) + 1
             if target.is_absolute():
                 errors.append(
                     f"{document.relative_to(ROOT)}:{line}: absolute local link: {raw}"
@@ -70,6 +105,18 @@ def main() -> int:
                 errors.append(
                     f"{document.relative_to(ROOT)}:{line}: missing local target: {raw}"
                 )
+                continue
+
+            # Validate fragment if present
+            if parsed.fragment:
+                if resolved.suffix == ".md":
+                    target_text = resolved.read_text(encoding="utf-8")
+                    target_anchors = extract_heading_anchors(target_text)
+                    if parsed.fragment not in target_anchors:
+                        errors.append(
+                            f"{document.relative_to(ROOT)}:{line}: "
+                            f"fragment not found in {resolved.relative_to(ROOT)}: {raw}"
+                        )
 
     if errors:
         for error in errors:

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Check local links in first-party Markdown without crawling the network."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LINK = re.compile(r"!?\[[^\]]*\]\((?P<target><[^>]+>|[^\s)]+)(?:\s+[^)]*)?\)")
+REMOTE_SCHEMES = {"http", "https", "mailto", "data"}
+
+
+def markdown_files() -> list[Path]:
+    roots = [
+        ROOT / name
+        for name in (
+            "README.md",
+            "CONTRIBUTING.md",
+            "SECURITY.md",
+            "THIRD_PARTY.md",
+        )
+    ]
+    trees = [ROOT / name for name in ("docs", "apps", "examples", "scripts")]
+    files = [path for path in roots if path.is_file()]
+    for tree in trees:
+        if tree.is_dir():
+            files.extend(tree.rglob("*.md"))
+    for path in (
+        ROOT / "integrations/README.md",
+        ROOT / "integrations/open3d/README.md",
+    ):
+        if path.is_file():
+            files.append(path)
+    return sorted(set(files))
+
+
+def main() -> int:
+    errors: list[str] = []
+    for document in markdown_files():
+        text = document.read_text(encoding="utf-8")
+        for match in LINK.finditer(text):
+            raw = match.group("target").strip("<>")
+            if raw.startswith("#"):
+                continue
+            parsed = urlsplit(raw)
+            if parsed.scheme.lower() in REMOTE_SCHEMES or parsed.netloc:
+                continue
+            if not parsed.path:
+                continue
+            target = Path(unquote(parsed.path))
+            line = text.count("\n", 0, match.start()) + 1
+            if target.is_absolute():
+                errors.append(
+                    f"{document.relative_to(ROOT)}:{line}: absolute local link: {raw}"
+                )
+                continue
+            resolved = (document.parent / target).resolve()
+            try:
+                resolved.relative_to(ROOT)
+            except ValueError:
+                errors.append(
+                    f"{document.relative_to(ROOT)}:{line}: link escapes repository: {raw}"
+                )
+                continue
+            if not resolved.exists():
+                errors.append(
+                    f"{document.relative_to(ROOT)}:{line}: missing local target: {raw}"
+                )
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(f"Local Markdown links verified in {len(markdown_files())} files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_provenance.py
+++ b/scripts/check_provenance.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Fail closed when audited areas escape the release ledger or package boundary."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_LEDGER_PATHS = (
+    "open4d/codecs/draco",
+    "open4d/codecs/klt",
+    "open4d/codecs/n4mc",
+    "open4d/codecs/qndf",
+    "open4d/codecs/qndf_int8",
+    "open4d/codecs/tsmc",
+    "open4d/codecs/tvmc",
+    "open4d/codecs/vdmc",
+    "open4d/reconstruction/rgbd",
+    "open4d/reconstruction/3dgstream",
+    "open4d/reconstruction/queen",
+    "open4d/reconstruction/gs_tools",
+    "integrations/unity",
+)
+ALLOWED_PACKAGES = {
+    "open4d",
+    "open4d.core",
+    "open4d.torch_ops",
+    "integrations",
+    "integrations.open3d",
+}
+
+
+def main() -> int:
+    errors: list[str] = []
+    ledger = (ROOT / "THIRD_PARTY.md").read_text(encoding="utf-8")
+    if "## Release decision: blocked" not in ledger:
+        errors.append("THIRD_PARTY.md must retain the explicit release block")
+
+    for path in REQUIRED_LEDGER_PATHS:
+        if not (ROOT / path).is_dir():
+            errors.append(f"expected audited area is missing: {path}")
+        if f"`{path}`" not in ledger:
+            errors.append(f"THIRD_PARTY.md has no entry for {path}")
+
+    with (ROOT / "pyproject.toml").open("rb") as stream:
+        project = tomllib.load(stream)
+    setuptools = project["tool"]["setuptools"]
+    packages = set(setuptools.get("packages", []))
+    if packages != ALLOWED_PACKAGES:
+        errors.append(
+            "package boundary changed: "
+            f"expected {sorted(ALLOWED_PACKAGES)}, got {sorted(packages)}"
+        )
+    if "find" in setuptools:
+        errors.append("automatic setuptools package discovery must remain disabled")
+
+    manifest = (ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    for path in ("open4d/codecs", "open4d/reconstruction", "integrations/unity"):
+        if f"prune {path}" not in manifest:
+            errors.append(f"MANIFEST.in must prune {path}")
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("Provenance coverage and distribution containment verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_provenance.py
+++ b/scripts/check_provenance.py
@@ -37,17 +37,51 @@ ALLOWED_PACKAGES = {
 }
 
 
+def parse_component_ledger(ledger: str) -> dict[str, str]:
+    """Parse the component ledger table and extract path -> decision mappings."""
+    component_map = {}
+    in_ledger = False
+    for line in ledger.split("\n"):
+        if "## Component ledger" in line:
+            in_ledger = True
+            continue
+        if in_ledger and line.startswith("##"):
+            break
+        if in_ledger and line.startswith("|") and not line.startswith("| Path"):
+            parts = [p.strip() for p in line.split("|")]
+            if len(parts) >= 5:
+                path_component = parts[1]
+                decision = parts[4]
+                # Extract path from backticks if present
+                if "`" in path_component:
+                    import re
+                    match = re.search(r"`([^`]+)`", path_component)
+                    if match:
+                        path = match.group(1)
+                        # Extract decision keyword (BLOCK or EXCLUDED)
+                        if "BLOCK" in decision:
+                            component_map[path] = "BLOCK"
+                        elif "EXCLUDED" in decision:
+                            component_map[path] = "EXCLUDED"
+    return component_map
+
+
 def main() -> int:
     errors: list[str] = []
     ledger = (ROOT / "THIRD_PARTY.md").read_text(encoding="utf-8")
     if "## Release decision: blocked" not in ledger:
         errors.append("THIRD_PARTY.md must retain the explicit release block")
 
+    component_ledger = parse_component_ledger(ledger)
+
     for path in REQUIRED_LEDGER_PATHS:
         if not (ROOT / path).is_dir():
             errors.append(f"expected audited area is missing: {path}")
-        if f"`{path}`" not in ledger:
-            errors.append(f"THIRD_PARTY.md has no entry for {path}")
+        if path not in component_ledger:
+            errors.append(
+                f"THIRD_PARTY.md component ledger has no row with valid "
+                f"BLOCK or EXCLUDED decision for {path}"
+            )
 
     with (ROOT / "pyproject.toml").open("rb") as stream:
         project = tomllib.load(stream)

--- a/scripts/check_provenance.py
+++ b/scripts/check_provenance.py
@@ -38,6 +38,12 @@ ALLOWED_PACKAGES = {
 
 
 def main() -> int:
+    """
+    Validate release provenance coverage and package distribution boundaries.
+    
+    Returns:
+    	int: `1` if any required validation fails, otherwise `0`.
+    """
     errors: list[str] = []
     ledger = (ROOT / "THIRD_PARTY.md").read_text(encoding="utf-8")
     if "## Release decision: blocked" not in ledger:

--- a/scripts/check_release_gate.py
+++ b/scripts/check_release_gate.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Block the supported release workflow while provenance entries are unresolved."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def blockers() -> list[str]:
+    ledger = (ROOT / "THIRD_PARTY.md").read_text(encoding="utf-8")
+    rows: list[str] = []
+    for line in ledger.splitlines():
+        if line.startswith("|") and re.search(r"\bBLOCK\b", line):
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            rows.append(cells[0] if cells else line)
+    if "## Release decision: blocked" in ledger and not rows:
+        rows.append("release decision remains blocked")
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--expect-blocked",
+        action="store_true",
+        help="succeed only when the repository is still explicitly blocked",
+    )
+    args = parser.parse_args()
+    unresolved = blockers()
+    if args.expect_blocked:
+        if not unresolved:
+            print("ERROR: release block disappeared without a cleared ledger", file=sys.stderr)
+            return 1
+        print(f"Release remains blocked by {len(unresolved)} ledger entries.")
+        return 0
+    if unresolved:
+        print("ERROR: release is blocked by unresolved provenance entries:", file=sys.stderr)
+        for path in unresolved:
+            print(f"  - {path}", file=sys.stderr)
+        return 1
+    print("Release ledger has no unresolved BLOCK entries.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_gate.py
+++ b/scripts/check_release_gate.py
@@ -13,6 +13,12 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def blockers() -> list[str]:
+    """
+    Collect unresolved release blockers from the third-party ledger.
+    
+    Returns:
+    	list[str]: Blocker descriptions found in matching ledger rows, or a release-decision message when the ledger remains blocked without matching rows.
+    """
     ledger = (ROOT / "THIRD_PARTY.md").read_text(encoding="utf-8")
     rows: list[str] = []
     for line in ledger.splitlines():
@@ -25,6 +31,15 @@ def blockers() -> list[str]:
 
 
 def main() -> int:
+    """
+    Run the release gate and report whether unresolved release blockers remain.
+    
+    With ``--expect-blocked``, succeeds only when at least one blocker exists.
+    Otherwise, succeeds when the release ledger has no unresolved blockers.
+    
+    Returns:
+        int: ``0`` when the release state matches the selected mode, otherwise ``1``.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--expect-blocked",

--- a/scripts/check_sdist_contents.py
+++ b/scripts/check_sdist_contents.py
@@ -32,6 +32,15 @@ ALLOWED_EGG_INFO = {
 
 
 def check_sdist(path: Path) -> list[str]:
+    """
+    Validate a gzip-compressed source distribution against the expected file inventory.
+    
+    Parameters:
+    	path (Path): Path to the source-distribution archive.
+    
+    Returns:
+    	list[str]: Validation error messages, or an empty list when the archive is valid.
+    """
     if not path.is_file():
         return [f"source distribution does not exist: {path}"]
     errors: list[str] = []
@@ -65,6 +74,12 @@ def check_sdist(path: Path) -> list[str]:
 
 
 def main() -> int:
+    """
+    Validate a source distribution from the command line and report its status.
+    
+    Returns:
+    	int: `1` if validation errors are found, `0` otherwise.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("sdist", type=Path)
     args = parser.parse_args()

--- a/scripts/check_sdist_contents.py
+++ b/scripts/check_sdist_contents.py
@@ -38,13 +38,31 @@ def check_sdist(path: Path) -> list[str]:
     expected_python = expected_python_files()
     with tarfile.open(path, "r:gz") as archive:
         files = [member for member in archive.getmembers() if member.isfile()]
-        stripped: set[str] = set()
+        raw_names = [member.name for member in files]
+        if len(raw_names) != len(set(raw_names)):
+            seen = set()
+            for name in raw_names:
+                if name in seen:
+                    errors.append(f"duplicate archive member: {name}")
+                seen.add(name)
+
+        stripped_list: list[str] = []
         for member in files:
             parts = PurePosixPath(member.name).parts
             if len(parts) < 2:
                 errors.append(f"member has no distribution root: {member.name}")
                 continue
-            stripped.add(PurePosixPath(*parts[1:]).as_posix())
+            stripped_path = PurePosixPath(*parts[1:]).as_posix()
+            stripped_list.append(stripped_path)
+
+        if len(stripped_list) != len(set(stripped_list)):
+            seen = set()
+            for name in stripped_list:
+                if name in seen:
+                    errors.append(f"duplicate root-normalized path: {name}")
+                seen.add(name)
+
+        stripped: set[str] = set(stripped_list)
 
     python_files = {name for name in stripped if name.endswith(".py")}
     if python_files != expected_python:

--- a/scripts/check_sdist_contents.py
+++ b/scripts/check_sdist_contents.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Reject research, generated, test, or binary content in the source archive."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+
+from check_wheel_contents import expected_python_files
+
+
+ALLOWED_ROOT_FILES = {
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "MANIFEST.in",
+    "PKG-INFO",
+    "README.md",
+    "SECURITY.md",
+    "THIRD_PARTY.md",
+    "pyproject.toml",
+    "setup.cfg",
+}
+ALLOWED_EGG_INFO = {
+    "PKG-INFO",
+    "SOURCES.txt",
+    "dependency_links.txt",
+    "requires.txt",
+    "top_level.txt",
+}
+
+
+def check_sdist(path: Path) -> list[str]:
+    if not path.is_file():
+        return [f"source distribution does not exist: {path}"]
+    errors: list[str] = []
+    expected_python = expected_python_files()
+    with tarfile.open(path, "r:gz") as archive:
+        files = [member for member in archive.getmembers() if member.isfile()]
+        stripped: set[str] = set()
+        for member in files:
+            parts = PurePosixPath(member.name).parts
+            if len(parts) < 2:
+                errors.append(f"member has no distribution root: {member.name}")
+                continue
+            stripped.add(PurePosixPath(*parts[1:]).as_posix())
+
+    python_files = {name for name in stripped if name.endswith(".py")}
+    if python_files != expected_python:
+        errors.append(
+            "source Python inventory differs: "
+            f"missing={sorted(expected_python - python_files)}, "
+            f"extra={sorted(python_files - expected_python)}"
+        )
+
+    for name in stripped - python_files:
+        parts = PurePosixPath(name).parts
+        if name in ALLOWED_ROOT_FILES:
+            continue
+        if len(parts) == 2 and parts[0].endswith(".egg-info") and parts[1] in ALLOWED_EGG_INFO:
+            continue
+        errors.append(f"unexpected source-distribution member: {name}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sdist", type=Path)
+    args = parser.parse_args()
+    errors = check_sdist(args.sdist)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(f"Source boundary verified: {args.sdist}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -26,11 +26,23 @@ PACKAGE_DIRS = {
 
 
 def configured_packages() -> set[str]:
+    """
+    Read the package names configured in the project's `pyproject.toml`.
+    
+    Returns:
+        set[str]: The configured setuptools package names.
+    """
     with (ROOT / "pyproject.toml").open("rb") as stream:
         return set(tomllib.load(stream)["tool"]["setuptools"]["packages"])
 
 
 def expected_python_files() -> set[str]:
+    """
+    Build the set of Python file paths expected in the wheel archive.
+    
+    Returns:
+    	set[str]: Archive paths for Python files found in the configured package directories.
+    """
     expected: set[str] = set()
     for package, directory in PACKAGE_DIRS.items():
         archive_directory = package.replace(".", "/")
@@ -41,6 +53,15 @@ def expected_python_files() -> set[str]:
 
 
 def check_wheel(path: Path) -> list[str]:
+    """
+    Validate a wheel's contents and metadata against the expected lightweight package layout.
+    
+    Parameters:
+        path (Path): Path to the wheel file to validate.
+    
+    Returns:
+        list[str]: Validation error messages, empty when the wheel passes all checks.
+    """
     errors: list[str] = []
     if configured_packages() != set(PACKAGE_DIRS):
         errors.append("pyproject package list differs from the wheel checker")
@@ -100,6 +121,11 @@ def check_wheel(path: Path) -> list[str]:
 
 
 def main() -> int:
+    """Validate the specified wheel and report whether its contents meet the expected boundary.
+    
+    Returns:
+    	int: `1` when validation errors are found, otherwise `0`.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("wheel", type=Path)
     args = parser.parse_args()

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Assert the exact contents and metadata of the lightweight wheel."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_DIRS = {
+    "open4d": ROOT / "open4d",
+    "open4d.core": ROOT / "open4d/core",
+    "open4d.torch_ops": ROOT / "open4d/torch_ops",
+    "integrations": ROOT / "integrations",
+    "integrations.open3d": ROOT / "integrations/open3d",
+}
+
+
+def configured_packages() -> set[str]:
+    with (ROOT / "pyproject.toml").open("rb") as stream:
+        return set(tomllib.load(stream)["tool"]["setuptools"]["packages"])
+
+
+def expected_python_files() -> set[str]:
+    expected: set[str] = set()
+    for package, directory in PACKAGE_DIRS.items():
+        archive_directory = package.replace(".", "/")
+        expected.update(
+            f"{archive_directory}/{source.name}" for source in directory.glob("*.py")
+        )
+    return expected
+
+
+def check_wheel(path: Path) -> list[str]:
+    errors: list[str] = []
+    if configured_packages() != set(PACKAGE_DIRS):
+        errors.append("pyproject package list differs from the wheel checker")
+    if not path.is_file():
+        return errors + [f"wheel does not exist: {path}"]
+
+    with zipfile.ZipFile(path) as wheel:
+        members = {name for name in wheel.namelist() if not name.endswith("/")}
+        python_files = {name for name in members if name.endswith(".py")}
+        expected_python = expected_python_files()
+        if expected_python - python_files:
+            errors.append(f"missing Python files: {sorted(expected_python - python_files)}")
+        if python_files - expected_python:
+            errors.append(f"unexpected Python files: {sorted(python_files - expected_python)}")
+
+        dist_info = {
+            name.split("/", 1)[0]
+            for name in members
+            if name.split("/", 1)[0].endswith(".dist-info")
+        }
+        if len(dist_info) != 1:
+            return errors + [f"expected one .dist-info directory, found {sorted(dist_info)}"]
+        metadata_dir = next(iter(dist_info))
+        expected_metadata = {
+            f"{metadata_dir}/METADATA",
+            f"{metadata_dir}/WHEEL",
+            f"{metadata_dir}/RECORD",
+            f"{metadata_dir}/top_level.txt",
+            f"{metadata_dir}/licenses/LICENSE",
+        }
+        missing_metadata = expected_metadata - members
+        if missing_metadata:
+            errors.append(f"missing wheel metadata: {sorted(missing_metadata)}")
+        unexpected = members - expected_python - expected_metadata
+        if unexpected:
+            errors.append(f"unexpected wheel members: {sorted(unexpected)}")
+
+        metadata_path = f"{metadata_dir}/METADATA"
+        if metadata_path in members:
+            metadata = Parser().parsestr(wheel.read(metadata_path).decode("utf-8"))
+            base_requirements = [
+                value
+                for value in metadata.get_all("Requires-Dist", [])
+                if "extra ==" not in value
+            ]
+            if metadata.get("Name", "").lower() != "open4d":
+                errors.append(f"unexpected distribution name: {metadata.get('Name')!r}")
+            if base_requirements != ["numpy"]:
+                errors.append(f"base wheel is not NumPy-only: {base_requirements}")
+            if metadata.get("License-Expression") != "MIT":
+                errors.append("wheel must use the MIT SPDX license expression")
+            if metadata.get("Requires-Python") != "<3.14,>=3.10":
+                errors.append(
+                    f"unexpected Python requirement: {metadata.get('Requires-Python')!r}"
+                )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wheel", type=Path)
+    args = parser.parse_args()
+    errors = check_wheel(args.wheel)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(f"Wheel boundary verified: {args.wheel}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_wheel_contents.py
+++ b/scripts/check_wheel_contents.py
@@ -48,7 +48,15 @@ def check_wheel(path: Path) -> list[str]:
         return errors + [f"wheel does not exist: {path}"]
 
     with zipfile.ZipFile(path) as wheel:
-        members = {name for name in wheel.namelist() if not name.endswith("/")}
+        namelist = [name for name in wheel.namelist() if not name.endswith("/")]
+        if len(namelist) != len(set(namelist)):
+            seen = set()
+            for name in namelist:
+                if name in seen:
+                    errors.append(f"duplicate wheel member: {name}")
+                seen.add(name)
+
+        members = set(namelist)
         python_files = {name for name in members if name.endswith(".py")}
         expected_python = expected_python_files()
         if expected_python - python_files:


### PR DESCRIPTION
## What changed

- publishes the versioned `v0.2-dev` contributor handbook source and links it from the root README
- replaces namespace package discovery with a literal five-package lightweight boundary
- adds exact wheel and source-distribution assertions plus a clean-install smoke path
- adds a third-party provenance ledger and a release workflow that fails while `BLOCK` entries remain
- adds contribution, security, PR, CodeRabbit, and Blacksmith-backed GitHub Actions configuration
- restores Frame/provider/Sequence lifecycle and edge-case coverage and rejects integer attribute overflow

## Why

The repository combines MIT project code with isolated research trees, datasets, papers, checkpoints, native binaries, GPL code, and non-commercial/no-redistribution terms. Automatic discovery and the absence of CI made it possible to ship unintended material under MIT-only metadata.

## Validation

- Blacksmith-backed CI: all nine Python, Open3D, packaging, documentation, and provenance jobs pass
- CodeRabbit: installed, configuration accepted, automatic draft review queued
- Python 3.11, 3.12, 3.13: 154 default tests pass locally
- Python 3.10: 78 core tests pass locally; full macOS visualization tier is blocked by a SciPy binary/linker incompatibility and is covered by Linux CI
- Open3D 0.19 / Python 3.12: 5 tests pass
- exact wheel and sdist checks pass
- clean Python 3.12 wheel install and dependency check pass
- Markdown links, YAML syntax, compilation, shell syntax, provenance containment, release-block presence, and whitespace checks pass

## Release impact

Release publication remains intentionally blocked. This PR provides containment and an auditable gate; it does not resolve the ledger license and provenance blockers.

## Remaining external setup

GitHub must initialize the enabled Wiki once before the prepared wiki repository can be pushed. Required merge checks should be configured after this PR establishes their exact GitHub check names.