### PR TITLE
Add optimized V-DMC codec submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ benchmark_app/archives/
 # Codec datasets, training runs, and generated reconstructions
 # Existing tracked paper fixtures remain tracked; these rules prevent new local
 # runs from silently expanding the source repository.
+4d_files/
 open4d/codecs/*/datasets/
 open4d/codecs/*/outputs/
 open4d/codecs/*/experiments/

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,7 @@
 [submodule "open4d/codecs/qndf/ssp_remesh/libigl"]
 	path = open4d/codecs/qndf/ssp_remesh/libigl
 	url = https://github.com/libigl/libigl.git
+[submodule "open4d/codecs/faster_vdmc"]
+	path = open4d/codecs/faster_vdmc
+	url = https://github.com/cicm4/mpeg-vdmc-tm.git
+	branch = faster_vdmc

--- a/open4d/codecs/README.md
+++ b/open4d/codecs/README.md
@@ -9,6 +9,7 @@ The directory names are stable, lowercase identifiers:
 - `draco`, `klt`, `n4mc`, `qndf`, and `qndf_int8`
 - `tsmc` and `tvmc`
 - `vdmc`, the pinned MPEG V-DMC test-model submodule
+- `faster_vdmc`, Open4D's performance-oriented V-DMC fork
 
 These implementations are not imported by the lightweight `open4d` package and
 their heavyweight dependencies remain optional.


### PR DESCRIPTION
## Summary

- add `open4d/codecs/faster_vdmc` as a separate submodule for Open4D's performance-oriented V-DMC fork
- keep `open4d/codecs/vdmc` unchanged as the pinned MPEG reference implementation
- retain the deterministic texture-transfer and exact mesh/UV hot-path improvements
- add ordered multi-process GOF encoding, HM all-intra and HEVC tile controls, and an optional x265 Main10 encoder with WPP/frame-thread/slice controls
- track the fork's `faster_vdmc` branch, pinned to `9d9b229`

## Implementation

The parent process can encode independent GOFs concurrently in isolated child processes, then merges their V3C units and checksum records in source order. GOF/VPS indices are retained, temporary payloads are deleted after a successful merge, and aggregate in-encoder metrics are rejected in parallel mode because those must be computed after decode.

The existing HM encoder now supports all-intra coding and uniform HEVC tiles. Tiles are valid and independently decodable, but reference HM does not schedule them concurrently, so they are exposed as a partitioning control rather than presented as a speed optimization.

The optional x265 path encodes Main10 HEVC directly in memory and returns reconstructed pictures to the V-DMC conformance pipeline. It supports CQP, presets, WPP, frame threads, worker-pool threads, all-intra, and independent slices. x265 is opt-in at configure time (`USE_X265_VIDEO_CODEC=ON`) because statically linking it carries GPL licensing obligations.

## Performance

Measured on the 24-core/48-thread Threadripper 7960X VPM using the user's 4D sequence:

| Mode | Window | Encode wall | Attribute stage | Attribute bytes | Validation |
|---|---:|---:|---:|---:|---:|
| Threaded HM baseline (mean) | 10 frames | 120.477 s | 73.783 s | 32,580 | prior exact baseline |
| x265 WPP + 4 frame threads | 10 frames | **55.61 s** | **7.986 s** | 40,784 | 20 EQUAL, 0 DIFF |
| x265 all-intra + WPP | 10 frames | 56.12 s | **7.757 s** | 86,558 | 20 EQUAL, 0 DIFF |
| HM baseline | 3 frames | 35.58 s | 20.410 s | 10,222 | prior exact baseline |
| HM all-intra | 3 frames | **24.51 s** | **9.244 s** | 10,210 | 6 EQUAL, 0 DIFF |
| HM all-intra, 2x2 tiles | 3 frames | 24.71 s | 9.407 s | 10,631 | 6 EQUAL, 0 DIFF |

The recommended x265 inter mode is 53.8% faster end-to-end and 89.2% faster in the attribute stage than the threaded HM baseline. Its complete `.vmesh` is 119,157 bytes versus 112,021 bytes for the matching baseline start window (+6.4%). The all-intra option has similar speed but a substantially larger stream in exchange for independent pictures.

For two 3-frame GOFs, ordered two-process encoding with 24 texture workers per process reduced wall time from 33.75 s to 17.12 s (49.3%). The serial and merged parallel `.vmesh` files had the same SHA-256, and both decodes reported 12 EQUAL and 0 DIFF.

## Visual quality validation

The matching 10-frame reference, original V-DMC/HM decode, and x265 decode were loaded with `examples/visualization/compare_sequences.py` using the same frame order, Y-up transform, camera, and MPEG point-to-plane metric.

HM and x265 produced identical geometry results, as expected because x265 replaces only attribute-video coding:

| Geometry metric | Original V-DMC/HM | x265 |
|---|---:|---:|
| Mean symmetric point-to-plane PSNR | 63.67 dB | 63.67 dB |
| Sequence symmetric RMS | 3.1449 | 3.1449 |
| Sequence Hausdorff | 71.885 | 71.885 |
| Worst frame | 0 | 0 |

The example viewer's built-in OBJ reader intentionally ignores materials and texture maps, so a second fixed-camera render loaded each OBJ's UVs plus its original JPEG or decoded PNG. Original-to-HM and original-to-x265 ten-frame animations were inspected side by side. The x265 result remained visually comparable at this inspection scale, with no obvious new structural or texture failure. This is supporting visual evidence, not a substitute for occupied-surface PSNR/SSIM; formal attribute-quality parity remains a follow-up gate.

Generated comparison GIFs and copied datasets remain in ignored `.context` storage and are deliberately not added to the repository.

## Recommended performance mode

For deployments where x265's GPL obligations are acceptable, use inter-coded x265 with WPP, four frame threads, a 24-thread pool, one slice, and the `fast` preset. It provides the best measured practical default: 53.5% lower total encode time with a 6.4% larger complete stream, correct decoder reconstruction, unchanged geometry quality, and no intentional quality-reduction switch. The repository keeps x265 configure-time opt-in until licensing and formal occupied-texture quality gates are resolved.

## Validation

- Release encoder and decoder built with x265 Main10 on the VPM
- existing HM, HM all-intra, HM 2x2 tiles, x265 inter, and x265 all-intra streams decoded successfully
- all tested encoder reconstruction checks matched decoder output (0 DIFF)
- serial and two-process GOF output was byte-identical
- x265 is disabled by default, leaving the project’s default dependency/license surface unchanged
