### PR TITLE
Fully disable CodeRabbit repository features

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,56 +1,91 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-language: en-US
+#
+# CodeRabbit is disabled for this repository. Keep this file as a tombstone so
+# organization-level defaults cannot silently turn repository features back on.
+# Removing the repository from the CodeRabbit GitHub App installation is still
+# required to revoke the app's access and prevent manually requested reviews.
+inheritance: false
 early_access: false
+enable_free_tier: false
 
 reviews:
-  profile: assertive
-  request_changes_workflow: true
-  high_level_summary: true
-  poem: false
-  review_status: true
+  request_changes_workflow: false
+  high_level_summary: false
+  review_status: false
+  review_progress: false
+  commit_status: false
+  auto_apply_labels: false
+  auto_assign_reviewers: false
+  slop_detection:
+    enabled: false
   auto_review:
     enabled: false
+    auto_incremental_review: false
+    description_keyword: ""
+    labels: []
     drafts: false
-    base_branches:
-      - main
-  path_filters:
-    - "!**/*.lock"
-    - "!**/*.zip"
-    - "!**/*.pdf"
-    - "!**/*.pt"
-    - "!**/*.pth"
-    - "!**/*.so"
-    - "!**/*.dylib"
-    - "!build/**"
-    - "!dist/**"
-    - "!open4d/codecs/**/data/**"
-    - "!open4d/codecs/**/outputs/**"
-    - "!open4d/reconstruction/**/data/**"
-    - "!open4d/reconstruction/**/outputs/**"
-  path_instructions:
-    - path: "pyproject.toml"
-      instructions: |
-        Reject automatic package discovery or any change that can include
-        research codecs, reconstruction systems, datasets, or native binaries
-        in the lightweight distribution. The base dependency must stay NumPy-only.
-    - path: "scripts/check_*contents.py"
-      instructions: |
-        Treat missing checks, permissive globs, and unaccounted archive members
-        as release-safety defects. Exact distribution contents must fail closed.
-    - path: "open4d/core/**"
-      instructions: |
-        Preserve canonical dtypes, laziness, finite random access, timestamp
-        validation, topology declarations, cleanup, and error propagation.
-    - path: "docs/**/*.md"
-      instructions: |
-        Flag broken links and claims that do not name evidence, environment, or
-        the distinction between isolated research behavior and Open4D integration.
-    - path: "THIRD_PARTY.md"
-      instructions: |
-        Never infer license clearance. New copied code, data, models, media,
-        binaries, papers, or submodules require immutable provenance and an
-        explicit release decision.
+    base_branches: []
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+    autofix:
+      enabled: false
+    fix_ci:
+      enabled: false
+    resolve_merge_conflict:
+      enabled: false
+    custom: []
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: "off"
+    custom_checks: []
+  post_merge_actions: []
 
 chat:
   auto_reply: false
+  allow_non_org_members: false
   art: false
+  integrations:
+    jira:
+      usage: disabled
+    linear:
+      usage: disabled
+
+knowledge_base:
+  # This also requests deletion of retained repository learnings and context.
+  opt_out: true
+  web_search:
+    enabled: false
+  code_guidelines:
+    enabled: false
+  jira:
+    usage: disabled
+  linear:
+    usage: disabled
+  mcp:
+    usage: disabled
+    disabled_servers: []
+  automatic_repository_linking: false
+  linked_repositories: []
+
+issue_enrichment:
+  auto_enrich:
+    enabled: false
+  planning:
+    enabled: false
+    auto_planning:
+      enabled: false
+      labels: []
+  labeling:
+    labeling_instructions: []
+    auto_apply_labels: false

--- a/docs/handbook/v0.2-dev/implementation-status.md
+++ b/docs/handbook/v0.2-dev/implementation-status.md
@@ -32,7 +32,7 @@ flowchart TB
 | Third-party/provenance ledger | Root ledger covers the high-risk research, data, model, binary, paper, and submodule areas | Resolve each entry with immutable provenance and reviewed distribution terms |
 | License/distribution gate | Supported release workflow fails while `BLOCK` entries remain | Resolve TVMC, QNDF, copied-upstream, binary, dataset, checkpoint, and paper scope |
 | Continuous integration | Blacksmith-backed GitHub Actions workflow, Python/Open3D matrices, packaging smoke test, links, syntax, provenance, and release checks prepared | Verify all GitHub checks on this pull request |
-| CodeRabbit | Version-controlled automatic-review configuration enabled for draft and ready pull requests | Confirm the installed app reviews this pull request |
+| CodeRabbit | Repository features disabled in version-controlled configuration | Remove this repository from the CodeRabbit GitHub App installation to revoke access |
 | Protected merge policy | No repository ruleset recorded at the audit point | Require the verified CI checks after their exact GitHub check names exist |
 
 ## Verified baseline that remains
@@ -65,14 +65,15 @@ The working tree does **not** currently contain the proposed `open4d.io` or
 application, TVMC shared adapter, RGB-D finite replay adapter, or live-stream
 contract implementation. These are roadmap items, not current capabilities.
 
-CodeRabbit and Blacksmith are automation surfaces, not evidence by themselves.
-Their pull-request results must still prove the tests, packaging boundary,
-provenance containment, and release block implemented in this branch.
+Blacksmith is an automation surface, not evidence by itself. Its pull-request
+results must still prove the tests, packaging boundary, provenance containment,
+and release block implemented in this branch.
 
 ## Immediate order of work
 
 1. Initialize and publish the enabled Wiki, then review and merge the handbook.
-2. Verify CodeRabbit and the complete Blacksmith matrix on the pull request.
-3. Configure protected-merge checks using the stable check names from that run.
-4. Resolve the provenance ledger's `BLOCK` entries; do not publish meanwhile.
-5. Begin P1 only after P0 acceptance criteria are green.
+2. Remove this repository from the CodeRabbit GitHub App installation.
+3. Verify the complete Blacksmith matrix on the pull request.
+4. Configure protected-merge checks using the stable check names from that run.
+5. Resolve the provenance ledger's `BLOCK` entries; do not publish meanwhile.
+6. Begin P1 only after P0 acceptance criteria are green.


### PR DESCRIPTION
# What changed

Disable every repository-configurable CodeRabbit surface, opt out of retained knowledge data, and keep a tombstone configuration that blocks inherited organization defaults. Update the implementation status to identify GitHub App removal as the remaining access-revocation step.

## Verification

- Commands and results: CodeRabbit configuration validated against `schema.v2.json`; `python3 scripts/check_markdown_links.py` verified 24 files; `git diff --check origin/main...` passed.
- Python, OS, GPU/hardware: Python 3.13.15 on macOS 27.0; no GPU or special hardware required.
- Input and output fixture/artifact: `.coderabbit.yaml` and the implementation-status handbook page; no generated artifacts.

## Safety checklist

- [x] Tests cover success, empty input, and relevant failure paths. (Not applicable to this configuration-only change; schema validation covers the edited configuration.)
- [x] Optional dependencies remain optional and have actionable errors.
- [x] Wheel/sdist boundaries are unchanged or their exact checks were updated.
- [x] `THIRD_PARTY.md` was updated for copied code, data, models, papers, media, binaries, or submodules. (No third-party materials were added.)
- [x] No credentials, private captures, generated outputs, or local datasets were added.
- [x] Documentation and status claims match verified behavior.

## Remaining limitations

A repository or organization admin must remove Open4D from the CodeRabbit GitHub App installation to revoke the app's access completely.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open4dfoundation/codesmith/Open4D/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789753095&installation_model_id=432509&pr_number=34&repository=open4dfoundation%2FOpen4D&return_to=https%3A%2F%2Fgithub.com%2Fopen4dfoundation%2FOpen4D%2Fpull%2F34&signature=e0bb10a661699b9f53a5eb2fb82b25cfedb72a8516bd5f4f4b54cd08abec7451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->