### PR TITLE
Fix PLY parsing and USD sequence edge cases

### DIFF
--- a/examples/visualization/formats_usd.py
+++ b/examples/visualization/formats_usd.py
@@ -46,6 +46,8 @@ with no faces) as a `UsdGeom.Points`. Both are read back the same way.
 from __future__ import annotations
 
 import datetime as _datetime
+import math
+from numbers import Real
 import sys
 from pathlib import Path
 from typing import Any, Iterable
@@ -72,6 +74,15 @@ _STREAM_TYPES = {
 }
 
 _NO_TRIANGLES = np.empty((0, 3), dtype=np.uint32)
+
+
+def _positive_fps(value: float) -> float:
+    if not isinstance(value, Real) or isinstance(value, bool):
+        raise TypeError("fps must be a real number")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0:
+        raise ValueError("fps must be finite and greater than zero")
+    return result
 
 
 def _pxr() -> tuple[Any, Any, Any, Any]:
@@ -183,7 +194,7 @@ class UsdSequenceProvider:
         }
 
         stage_fps = self._stage.GetTimeCodesPerSecond() or 24.0
-        self.fps = float(fps) if fps else float(stage_fps)
+        self.fps = _positive_fps(stage_fps if fps is None else fps)
 
         container = dict(
             (self._stage.GetRootLayer().customLayerData or {}).get("open4d", {})
@@ -336,6 +347,33 @@ def write_usd_container(
     Connectivity is written once when every frame shares it, and time-sampled
     only where it changes. The frames where it changes are the key frames.
     """
+    fps = _positive_fps(fps)
+    if not isinstance(up_axis, str) or up_axis.lower() not in {"y", "z"}:
+        raise ValueError("up_axis must be 'y' or 'z' for an OpenUSD stage")
+    up_axis = up_axis.lower()
+
+    # USD prim schemas and primvars must be chosen before samples are authored.
+    # Reiterable sequences are scanned without retaining their geometry; only a
+    # one-shot iterator needs materialization so it can survive the write pass.
+    iterator = iter(frames)
+    if iterator is frames:
+        frames = tuple(iterator)
+
+    frame_count = 0
+    has_triangles = False
+    has_colors = False
+    for index, frame in enumerate(frames):
+        frame_count = index + 1
+        has_triangles = has_triangles or len(frame.geometry.triangles) > 0
+        has_colors = has_colors or frame.geometry.colors is not None
+        if len(frame.geometry.positions) == 0:
+            raise ValueError(
+                f"frame {index} contains no positions; "
+                "USD containers require non-empty geometry"
+            )
+    if frame_count == 0:
+        raise ValueError("cannot write a container with no frames")
+
     Sdf, Usd, UsdGeom, Vt = _pxr()
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
@@ -370,10 +408,30 @@ def write_usd_container(
     stage.SetTimeCodesPerSecond(fps)
     stage.SetFramesPerSecond(fps)
 
-    geometry_prim: Any = None
-    points_attr = counts_attr = indices_attr = extent_attr = None
+    if has_triangles:
+        schema = UsdGeom.Mesh.Define(stage, PRIM_PATH)
+        counts_attr = schema.CreateFaceVertexCountsAttr()
+        indices_attr = schema.CreateFaceVertexIndicesAttr()
+    else:
+        schema = UsdGeom.Points.Define(stage, PRIM_PATH)
+        counts_attr = indices_attr = None
+    geometry_prim = schema.GetPrim()
+    points_attr = schema.CreatePointsAttr()
+    extent_attr = schema.CreateExtentAttr()
     color_primvar = None
+    if has_colors:
+        color_primvar = UsdGeom.PrimvarsAPI(geometry_prim).CreatePrimvar(
+            "displayColor",
+            Sdf.ValueTypeNames.Color3fArray,
+            UsdGeom.Tokens.vertex,
+        )
     streams: dict[str, Any] = {}
+    for name, type_name in _STREAM_TYPES.items():
+        streams[name] = geometry_prim.CreateAttribute(
+            f"open4d:{name}",
+            getattr(Sdf.ValueTypeNames, type_name),
+            custom=True,
+        )
 
     previous_triangles: np.ndarray | None = None
     first_triangles: np.ndarray | None = None
@@ -387,31 +445,6 @@ def write_usd_container(
         triangles = np.asarray(mesh.triangles, dtype=np.int32)
         time = Usd.TimeCode(index)
 
-        if geometry_prim is None:
-            # The first frame decides the prim type: a sequence with no faces
-            # is a point cloud, not a mesh with nothing in it.
-            if len(triangles) > 0:
-                schema = UsdGeom.Mesh.Define(stage, PRIM_PATH)
-                counts_attr = schema.CreateFaceVertexCountsAttr()
-                indices_attr = schema.CreateFaceVertexIndicesAttr()
-            else:
-                schema = UsdGeom.Points.Define(stage, PRIM_PATH)
-            geometry_prim = schema.GetPrim()
-            points_attr = schema.CreatePointsAttr()
-            extent_attr = schema.CreateExtentAttr()
-            if mesh.colors is not None:
-                color_primvar = UsdGeom.PrimvarsAPI(geometry_prim).CreatePrimvar(
-                    "displayColor",
-                    Sdf.ValueTypeNames.Color3fArray,
-                    UsdGeom.Tokens.vertex,
-                )
-            for name, type_name in _STREAM_TYPES.items():
-                streams[name] = geometry_prim.CreateAttribute(
-                    f"open4d:{name}",
-                    getattr(Sdf.ValueTypeNames, type_name),
-                    custom=True,
-                )
-
         points_attr.Set(Vt.Vec3fArray.FromNumpy(positions), time)
         extent_attr.Set(
             Vt.Vec3fArray.FromNumpy(
@@ -420,16 +453,15 @@ def write_usd_container(
             time,
         )
 
-        if color_primvar is not None and mesh.colors is not None:
-            colors = np.asarray(mesh.colors)
-            if np.issubdtype(colors.dtype, np.integer):
-                colors = colors / 255.0
-            color_primvar.Set(
-                Vt.Vec3fArray.FromNumpy(
-                    np.ascontiguousarray(colors[:, :3], dtype=np.float32)
-                ),
-                time,
-            )
+        if color_primvar is not None:
+            if mesh.colors is None:
+                colors = np.empty((0, 3), dtype=np.float32)
+            else:
+                colors = np.asarray(mesh.colors)
+                if np.issubdtype(colors.dtype, np.integer):
+                    colors = colors / 255.0
+                colors = np.ascontiguousarray(colors[:, :3], dtype=np.float32)
+            color_primvar.Set(Vt.Vec3fArray.FromNumpy(colors), time)
 
         is_key_frame = previous_triangles is None or not np.array_equal(
             previous_triangles, triangles
@@ -458,9 +490,6 @@ def write_usd_container(
         previous_triangles = triangles
         timestamps.append(timestamp)
         count = index + 1
-
-    if count == 0:
-        raise ValueError("cannot write a container with no frames")
 
     # Only frame 0 is a key frame, so connectivity never changed: replace the
     # single time sample with an unvarying value, which USD stores far more

--- a/examples/visualization/frame_sources.py
+++ b/examples/visualization/frame_sources.py
@@ -288,7 +288,8 @@ def open_sequence(path: Path | str, fps: float | None = None) -> Sequence:
     kind = source_kind(path)
 
     if kind == "folder":
-        return Sequence(FolderFrameProvider(path, fps=fps or DEFAULT_FPS))
+        folder_fps = DEFAULT_FPS if fps is None else fps
+        return Sequence(FolderFrameProvider(path, fps=folder_fps))
     if kind == "sequence-file":
         return SEQUENCE_OPENERS[path.suffix.lower()](path, fps)
     return Sequence(SingleFrameProvider(path))

--- a/examples/visualization/tests/test_formats_usd.py
+++ b/examples/visualization/tests/test_formats_usd.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pxr")
+
+import formats_usd
+from open4d import Frame, TriangleMesh
+
+pytestmark = pytest.mark.cpu
+
+
+def frame(index, triangles=(), colors=None, positions=None):
+    if positions is None:
+        positions = [[0, 0, 0], [1, 0, 0], [0, 1, 0]]
+    return Frame(
+        frame_index=index,
+        timestamp=index / 30,
+        geometry=TriangleMesh(
+            np.asarray(positions, dtype=np.float32),
+            np.asarray(triangles, dtype=np.uint32).reshape(-1, 3),
+            colors=colors,
+        ),
+    )
+
+
+def test_usd_round_trip_preserves_topology_and_colors_first_seen_later(tmp_path):
+    colors = np.array(
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+    frames = (frame(0), frame(1, [[0, 1, 2]], colors))
+    path = formats_usd.write_usd_container(
+        tmp_path / "mixed.usdc", (item for item in frames)
+    )
+
+    decoded = formats_usd.open_usd_sequence(path)
+
+    assert decoded.metadata["prim_type"] == "Mesh"
+    assert len(decoded[0].geometry.triangles) == 0
+    assert decoded[0].geometry.colors is None
+    np.testing.assert_array_equal(decoded[1].geometry.triangles, [[0, 1, 2]])
+    np.testing.assert_allclose(decoded[1].geometry.colors, colors)
+
+
+def test_usd_reader_rejects_an_explicit_zero_fps_override(tmp_path):
+    path = formats_usd.write_usd_container(tmp_path / "frame.usdc", [frame(0)])
+
+    with pytest.raises(ValueError, match="fps"):
+        formats_usd.open_usd_sequence(path, fps=0)
+
+
+def test_usd_writer_rejects_x_up_without_mislabelling_geometry(tmp_path):
+    destination = tmp_path / "frame.usdc"
+
+    with pytest.raises(ValueError, match="up_axis.*y.*z"):
+        formats_usd.write_usd_container(destination, [frame(0)], up_axis="x")
+
+    assert not destination.exists()
+
+
+def test_usd_writer_rejects_empty_geometry_before_touching_destination(tmp_path):
+    destination = tmp_path / "frame.usdc"
+    destination.write_text("keep me", encoding="utf-8")
+    empty = frame(0, positions=np.empty((0, 3), dtype=np.float32))
+
+    with pytest.raises(ValueError, match="frame 0.*no positions"):
+        formats_usd.write_usd_container(destination, [empty])
+
+    assert destination.read_text(encoding="utf-8") == "keep me"

--- a/examples/visualization/tests/test_frame_sources.py
+++ b/examples/visualization/tests/test_frame_sources.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+import frame_sources
+
+pytestmark = pytest.mark.cpu
+
+
+def test_folder_loader_rejects_an_explicit_zero_fps(tmp_path):
+    (tmp_path / "frame.obj").write_text(
+        "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="fps"):
+        frame_sources.open_sequence(tmp_path, fps=0)

--- a/open4d/io/_mesh.py
+++ b/open4d/io/_mesh.py
@@ -145,7 +145,92 @@ def _parse_ply_header(stream) -> tuple[str, list[dict[str, Any]], int]:
 def _ply_dtype(name: str) -> np.dtype:
     if name not in _PLY_DTYPES:
         raise UnsupportedPlyVariant(f"unsupported PLY property type {name!r}")
-    return np.dtype(_PLY_DTYPES[name])
+    return np.dtype(_PLY_DTYPES[name]).newbyteorder("<")
+
+
+def _ascii_face_indices(
+    row: list[bytes], properties: list[dict[str, Any]], path: Path
+) -> list[int]:
+    """Read the first face list while consuming every property in order."""
+    if len(properties) == 1 and properties[0]["list"] and row:
+        declared = int(row[0])
+        if len(row) != declared + 1:
+            raise ValueError(
+                f"{path} face declares {declared} indices "
+                f"but contains {len(row) - 1}"
+            )
+
+    cursor = 0
+    selected: list[int] | None = None
+    for prop in properties:
+        if cursor >= len(row):
+            raise ValueError(f"{path} contains a truncated ASCII face")
+        if not prop["list"]:
+            cursor += 1
+            continue
+
+        value_count = int(row[cursor])
+        cursor += 1
+        if value_count < 0 or cursor + value_count > len(row):
+            available = max(0, len(row) - cursor)
+            raise ValueError(
+                f"{path} face declares {value_count} values for "
+                f"{prop['name']!r} but contains {available}"
+            )
+        values = row[cursor : cursor + value_count]
+        cursor += value_count
+        if selected is None:
+            selected = [int(value) for value in values]
+
+    if cursor != len(row):
+        raise ValueError(
+            f"{path} face contains {len(row) - cursor} undeclared value(s)"
+        )
+    assert selected is not None
+    return selected
+
+
+def _read_exact(stream: Any, byte_count: int, path: Path) -> bytes:
+    data = stream.read(byte_count)
+    if len(data) != byte_count:
+        raise ValueError(f"{path} contains a truncated binary PLY element")
+    return data
+
+
+def _binary_face_indices(
+    stream: Any, properties: list[dict[str, Any]], path: Path
+) -> np.ndarray:
+    """Read the first face list while consuming every binary property."""
+    selected: np.ndarray | None = None
+    for prop in properties:
+        if not prop["list"]:
+            dtype = _ply_dtype(prop["type"])
+            _read_exact(stream, dtype.itemsize, path)
+            continue
+
+        count_dtype = _ply_dtype(prop["count_type"])
+        value_count = int(
+            np.frombuffer(
+                _read_exact(stream, count_dtype.itemsize, path),
+                dtype=count_dtype,
+                count=1,
+            )[0]
+        )
+        if value_count < 0:
+            raise ValueError(
+                f"{path} face declares a negative list count for {prop['name']!r}"
+            )
+        value_dtype = _ply_dtype(prop["value_type"])
+        values = np.frombuffer(
+            _read_exact(stream, value_dtype.itemsize * value_count, path),
+            dtype=value_dtype,
+            count=value_count,
+        )
+        if selected is None:
+            selected = values
+
+    assert selected is not None
+    return selected
 
 
 def read_ply(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
@@ -231,39 +316,22 @@ def read_ply(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
             elif name == "face":
                 corners: list[tuple[int, int, int]] = []
                 list_properties = [prop for prop in properties if prop["list"]]
-                if len(list_properties) != 1 or len(properties) != 1:
+                if not list_properties:
                     raise UnsupportedPlyVariant(
-                        f"{path} face elements must contain exactly one list property"
+                        f"{path} face elements must contain a list property"
                     )
-                list_property = list_properties[0]
 
                 if ascii_mode:
                     for row in rows:
-                        vertices_in_face = int(row[0])
-                        if len(row) != vertices_in_face + 1:
-                            raise ValueError(
-                                f"{path} face declares {vertices_in_face} indices "
-                                f"but contains {len(row) - 1}"
-                            )
-                        indices = [int(value) for value in row[1:]]
+                        indices = _ascii_face_indices(row, properties, path)
                         for corner in range(1, len(indices) - 1):
                             corners.append(
                                 (indices[0], indices[corner], indices[corner + 1])
                             )
                 else:
-                    count_dtype = _ply_dtype(list_property["count_type"])
-                    value_dtype = _ply_dtype(list_property["value_type"])
                     for _ in range(count):
-                        vertices_in_face = int(
-                            np.frombuffer(
-                                stream.read(count_dtype.itemsize), dtype=count_dtype
-                            )[0]
-                        )
-                        indices = np.frombuffer(
-                            stream.read(value_dtype.itemsize * vertices_in_face),
-                            dtype=value_dtype,
-                        )
-                        for corner in range(1, vertices_in_face - 1):
+                        indices = _binary_face_indices(stream, properties, path)
+                        for corner in range(1, len(indices) - 1):
                             corners.append(
                                 (
                                     int(indices[0]),

--- a/open4d/io/tests/test_sequence_io.py
+++ b/open4d/io/tests/test_sequence_io.py
@@ -173,25 +173,78 @@ def test_explicit_format_can_open_an_extensionless_file(tmp_path):
     assert len(frame.geometry.triangles) == 1
 
 
-def test_unusual_ply_face_layout_uses_the_trimesh_fallback(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "face_properties, face_row",
+    (
+        (
+            "property uchar material\n"
+            "property list uchar int vertex_indices\n",
+            "7 3 0 1 2\n",
+        ),
+        (
+            "property list uchar int vertex_indices\n"
+            "property uchar material\n",
+            "3 0 1 2 7\n",
+        ),
+    ),
+)
+def test_ascii_ply_face_list_respects_declared_property_order(
+    tmp_path, monkeypatch, face_properties, face_row
+):
     path = tmp_path / "frame.ply"
     path.write_text(
-        "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\n"
-        "property float y\nproperty float z\nelement face 1\n"
-        "property list uchar int vertex_indices\nproperty uchar material\n"
-        "end_header\n0 0 0\n1 0 0\n0 1 0\n3 0 1 2 7\n",
+        (
+            "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\n"
+            "property float y\nproperty float z\nelement face 1\n"
+        )
+        + face_properties
+        + "end_header\n0 0 0\n1 0 0\n0 1 0\n"
+        + face_row,
         encoding="ascii",
     )
-    calls = []
 
     def fallback(fallback_path):
-        calls.append(fallback_path)
-        return ([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], [[0, 1, 2]], None)
+        pytest.fail(f"valid face properties should not need trimesh: {fallback_path}")
 
     monkeypatch.setattr("open4d.io._mesh.read_with_trimesh", fallback)
 
-    assert len(open_sequence(path)[0].geometry.triangles) == 1
-    assert calls == [path]
+    triangles = open_sequence(path)[0].geometry.triangles
+    np.testing.assert_array_equal(triangles, [[0, 1, 2]])
+
+
+def test_binary_ply_face_list_respects_declared_property_order(tmp_path, monkeypatch):
+    path = tmp_path / "frame.ply"
+    header = (
+        "ply\nformat binary_little_endian 1.0\nelement vertex 3\n"
+        "property float x\nproperty float y\nproperty float z\n"
+        "element face 1\nproperty uchar material\n"
+        "property list uchar int vertex_indices\n"
+        "property float confidence\nend_header\n"
+    ).encode("ascii")
+    vertices = np.array(
+        [(0, 0, 0), (1, 0, 0), (0, 1, 0)],
+        dtype=np.dtype([("x", "<f4"), ("y", "<f4"), ("z", "<f4")]),
+    )
+    face = np.array(
+        [(7, 3, [0, 1, 2], 0.5)],
+        dtype=np.dtype(
+            [
+                ("material", "u1"),
+                ("count", "u1"),
+                ("indices", "<i4", 3),
+                ("confidence", "<f4"),
+            ]
+        ),
+    )
+    path.write_bytes(header + vertices.tobytes() + face.tobytes())
+
+    def fallback(fallback_path):
+        pytest.fail(f"valid face properties should not need trimesh: {fallback_path}")
+
+    monkeypatch.setattr("open4d.io._mesh.read_with_trimesh", fallback)
+
+    triangles = open_sequence(path)[0].geometry.triangles
+    np.testing.assert_array_equal(triangles, [[0, 1, 2]])
 
 
 def test_malformed_ply_is_a_decode_error_not_a_missing_dependency(tmp_path):


### PR DESCRIPTION
# What changed

Fix PLY face-property parsing and USD sequence packing/validation, including explicit FPS handling, later-frame topology and colors, unsupported X-up metadata, and empty-frame errors.

## Verification

- Commands and results: `python3 -m pytest -q` — 271 passed, 27 skipped; USD-enabled focused suite — 33 passed.
- Python, OS, GPU/hardware: Python 3.13, macOS, CPU; optional USD coverage used `usd-core` 26.8.
- Input and output fixture/artifact: synthetic ASCII/binary PLY fixtures and temporary USDC round trips.

## Safety checklist

- [x] Tests cover success, empty input, and relevant failure paths.
- [x] Optional dependencies remain optional and have actionable errors.
- [x] Wheel/sdist boundaries are unchanged or their exact checks were updated.
- [x] `THIRD_PARTY.md` was updated for copied code, data, models, papers, media, binaries, or submodules.
- [x] No credentials, private captures, generated outputs, or local datasets were added.
- [x] Documentation and status claims match verified behavior.

## Remaining limitations

X-up USD export remains unsupported and now fails explicitly; callers must rotate to Y/Z before packing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open4dfoundation/codesmith/Open4D/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790438247&installation_model_id=432509&pr_number=39&repository=open4dfoundation%2FOpen4D&return_to=https%3A%2F%2Fgithub.com%2Fopen4dfoundation%2FOpen4D%2Fpull%2F39&signature=b249704c694d7688019bd71b897f8623451cbfe5b483987e6def5f60dd29bb1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->