### PR TITLE
Reconcile documentation with the current implementation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,9 @@ is not legal approval to publish.
 - **Lightweight platform:** `open4d.core`, `open4d.torch_ops`, the Open3D
   adapter, examples, documentation, and CPU tests.
 - **Research codecs:** each directory under `open4d/codecs/` is an independent
-  experimental environment. Preserve the paper implementation and integrate
-  through narrow adapters.
+  experimental workflow. Its Python stages use the shared Python 3.12 codec
+  dependency set; native and GPU requirements remain component-specific.
+  Preserve the paper implementation and integrate through narrow adapters.
 - **RGB-D reconstruction and transport:** hardware, CUDA, and network work
   under `open4d/reconstruction/rgbd/`. Prefer synthetic or recorded tests.
 - **Gaussian reconstruction:** treat the imported research directories as
@@ -50,8 +51,8 @@ python -m pip install -e '.[dev,torch]'
 python -m pytest -m 'torch and not open3d' open4d/torch_ops/tests
 ```
 
-Registered markers are `cpu`, `open3d`, `torch`, `gpu`, `hardware`, and
-`slow`. Tests needing GPUs, physical hardware, local datasets, or graphical
+Registered markers are `cpu`, `open3d`, `torch`, `gpu`, `hardware`, `slow`, and
+`player`. Tests needing GPUs, physical hardware, local datasets, or graphical
 sessions must not run in the default tier.
 
 ## Required checks

--- a/README.md
+++ b/README.md
@@ -75,8 +75,13 @@ dependency-ordered roadmap.
 Open4D/
 ├── open4d/
 │   ├── core/          shared temporal geometry and sequence abstractions
+│   ├── io/            public mesh-file and manifested-directory I/O
+│   ├── codec/         shared sequence codec API and adapters
+│   ├── visualization/ public viewer and GIF renderer
+│   ├── torch_ops/      optional Torch geometry helpers
 │   ├── codecs/
 │   │   ├── draco/
+│   │   ├── faster_vdmc/
 │   │   ├── klt/
 │   │   ├── n4mc/
 │   │   ├── qndf/
@@ -85,7 +90,10 @@ Open4D/
 │   │   ├── tvmc/
 │   │   └── vdmc/
 │   └── reconstruction/
-│       └── rgbd/
+│       ├── rgbd/
+│       ├── queen/
+│       ├── 3dgstream/
+│       └── gs_tools/
 ├── integrations/
 │   ├── open3d/
 │   └── unity/
@@ -129,9 +137,13 @@ Open4D/
   video-based dynamic mesh coding. The `open4d/codecs/vdmc` submodule provides
   the standard's reference encoder, decoder, metric tools, and unit tests; it is
   separate from Open4D's TVMC research pipeline.
+- **Faster V-DMC** — a pinned performance-oriented fork of the same test model,
+  with exact-output and higher-throughput modes recorded in the
+  [benchmark report](docs/benchmarks/faster-vdmc.md).
 
-Each component has its own README and environment. See
-[Requirements](#requirements) for what each one adds on top of the baseline.
+Each component has its own README and may add native tools, GPU extensions, or
+hardware requirements to the shared Python baseline. See
+[Requirements](#requirements) for those additions.
 
 ## Requirements
 
@@ -153,9 +165,9 @@ dependencies. Extras add optional readers and viewers — see
 which the `[player]` extra installs, for its nearest-neighbour search — the same
 `cKDTree` query TVMC's own evaluation uses.
 
-### One environment for the codecs
+### One Python dependency set for the codecs
 
-Every codec runs in a single environment, described by
+The supported baseline for codec Python stages is described by
 [`environment.yml`](environment.yml) at the repository root:
 
 ```bash
@@ -164,12 +176,17 @@ conda activate open4d
 pip install -e .
 ```
 
-That is Python 3.12, NumPy 1.26.4, Open3D 0.19, PyTorch 2.7.0, and .NET 10 — one
-of each, where there used to be three Python versions, two Open3D versions, two
-PyTorch versions, and three .NET SDKs. The pins themselves live in
+The Python set is Python 3.12, NumPy 1.26.4, Open3D 0.19, and PyTorch 2.7.0.
+Native projects use one external .NET 10 SDK. This replaces three Python
+versions, two Open3D versions, two PyTorch versions, and three .NET targets. The
+Python pins themselves live in
 [`requirements-codecs.txt`](requirements-codecs.txt), which `environment.yml`
 installs; it lists direct dependencies only, so inside an existing Python 3.12
 environment `pip install -r requirements-codecs.txt` is equivalent.
+
+Codec-local setup scripts may create a convenience virtual environment, but
+they must use these same Python and package pins rather than defining a second
+dependency baseline. Native tools and GPU extensions remain separate.
 
 One trap worth naming, because its error message points the wrong way. The .NET
 projects target `net10.0`, and a distribution's own `dotnet` under
@@ -203,7 +220,7 @@ What each module needs beyond that shared environment:
 | `codecs/qndf`, `codecs/qndf_int8` | An NVIDIA GPU for training. Evaluation (`mesh_errors.py`) runs on CPU. Building the `ssp_remesh` preprocessor needs CMake and Eigen (`libeigen3-dev`/`brew install eigen`), plus the pinned libigl submodule |
 | `codecs/klt` | `kaolin` and an NVIDIA GPU; 24 GB is the same ceiling at resolution 128–256 |
 | `codecs/draco` | A CMake build of the vendored Draco submodule. Open3D, pymeshlab, and OpenCV are for evaluation only |
-| `codecs/vdmc` | The MPEG reference test model's own build requirements |
+| `codecs/vdmc`, `codecs/faster_vdmc` | The MPEG reference and optimized test models' own build requirements |
 | `reconstruction/rgbd` | Two hardware-synchronized RGB-D cameras, a Windows capture host, and an Ubuntu host with Python 3.10+, an NVIDIA GPU, and CUDA-enabled Open3D. Its legacy C++ pipeline additionally wants CUDA 12.x, Open3D 0.18, OpenCV, Eigen, jsoncpp, Draco, CMake, Ninja, and either the Azure Kinect SDK or the Orbbec K4A wrapper |
 | `integrations/unity` | Unity, plus a C++ toolchain to rebuild the backend for anything other than the prebuilt macOS and Android/Quest 3 plugins |
 
@@ -324,10 +341,11 @@ Playback uses `open4d.visualization`'s PyQt6 window: drag to orbit, scroll to zo
 to scrub, space to pause, left/right to step a frame. `--save out.gif` writes an
 animated GIF through the same renderer.
 
-A source is either a folder holding one mesh file per frame — `.obj` and `.ply`
-need no extra dependencies to read — or a single time-sampled USD file. `--info`
-reports frame count, duration, topology and bounds without decoding geometry,
-which is the quickest way to check a dataset loads.
+A viewer source may be one mesh file, a folder holding one mesh file per frame,
+or a single time-sampled USD file. OBJ and PLY need no extra dependency; the
+`[tools]` extra adds OFF, STL, GLB, and glTF, while `[usd]` adds USD files and
+folders. `--info` reports frame count, duration, topology and bounds without
+decoding geometry, which is the quickest way to check a dataset loads.
 
 The public Python loader handles local mesh files and frame folders in one call;
 frames are decoded on access:

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -8,11 +8,13 @@ is useful only when it names the revision it describes.
 
 | Snapshot | Repository revision | Audit date | State |
 | --- | --- | --- | --- |
-| [`v0.2-dev`](v0.2-dev/README.md) | `96b8c7bbb48e2a8d231684639cfc57799ca6666d` | 2026-08-13 | Current development baseline |
+| [`v0.2-dev`](v0.2-dev/README.md) | `96b8c7bbb48e2a8d231684639cfc57799ca6666d` | 2026-08-13 | Historical audit baseline with a separately maintained live-status page |
 
-Start with the current snapshot's [orientation and learning path](v0.2-dev/README.md).
-Then read its [current implementation status](v0.2-dev/implementation-status.md)
-for the live gap between the audited baseline and the roadmap.
+Start with the snapshot's [orientation and learning path](v0.2-dev/README.md).
+The technical chapters and component register describe the audited commit, not
+today's tree. The [current implementation status](v0.2-dev/implementation-status.md),
+[roadmap](v0.2-dev/roadmap.md), and orientation page's first commands are the
+maintained exceptions.
 When `v0.2` is released, this directory should be copied to `v0.2/` and frozen;
 future audits should create a new snapshot rather than rewriting history.
 

--- a/docs/handbook/v0.2-dev/README.md
+++ b/docs/handbook/v0.2-dev/README.md
@@ -19,7 +19,9 @@ version of the audit is:
 
 That audit remains frozen for reproducibility. The live gap between the
 audited baseline and the roadmap is tracked in
-[current implementation status](implementation-status.md).
+[current implementation status](implementation-status.md). The roadmap and the
+“First commands” section below are maintained with the live branch; the
+technical chapters and component register remain audit records.
 
 > **Complete means:** setup is reproducible, a licensed sample runs end to end,
 > automated tests pass, outputs are documented, and the component works through
@@ -56,14 +58,16 @@ triangle mesh. A Gaussian-splat renderer is not a mesh viewer. The project will
 become coherent by giving these jobs explicit boundaries, not by forcing every
 method into one data structure.
 
-## Current maturity
+## Maturity at the audited revision
 
-The strongest verified pieces are the NumPy-backed `TriangleMesh`, `Frame`,
-finite lazy `Sequence`, example loaders/comparison tools/viewers, and the
-Open3D adapter. The recorded audit has 106 passing core/visualization tests and
-5 passing Open3D tests on Python 3.12. The codec and RGB-D trees contain useful
-standalone pipelines, but none consumes and produces the shared `Sequence`
-interface. `apps/` is still a README-only scaffold.
+At commit `96b8c7b`, the strongest verified pieces were the NumPy-backed
+`TriangleMesh`, `Frame`, finite lazy `Sequence`, example loaders/comparison
+tools/viewers, and the Open3D adapter. The recorded audit has 106 passing
+core/visualization tests and 5 passing Open3D tests on Python 3.12. The codec
+and RGB-D trees contained useful standalone pipelines, but none consumed and
+produced the shared `Sequence` interface. `apps/` was a README-only scaffold.
+Several public codec adapters were added after this audit; use
+[current implementation status](implementation-status.md) for present behavior.
 
 Important cautions before publishing or redistributing anything:
 

--- a/docs/handbook/v0.2-dev/architecture.md
+++ b/docs/handbook/v0.2-dev/architecture.md
@@ -37,10 +37,13 @@ The important contracts are:
 The existing geometry/frame/provider/sequence separation and canonical NumPy
 dtypes should be preserved.
 
-## The actual v0.2-dev architecture
+## The architecture at the audited v0.2-dev revision
 
-The public core exists, but most useful I/O and measurement code is in examples,
-and every research pipeline uses its own file/tensor/Open3D conventions:
+At commit `96b8c7b`, the public core existed, but most useful I/O and measurement
+code was in examples, and every research pipeline used its own
+file/tensor/Open3D conventions. This diagram is historical; see
+[current implementation status](implementation-status.md) for adapters and
+public APIs added after the audit.
 
 ```mermaid
 flowchart TB

--- a/docs/handbook/v0.2-dev/contributing.md
+++ b/docs/handbook/v0.2-dev/contributing.md
@@ -75,14 +75,16 @@ The intended root markers are:
 - `torch`: Torch CPU or GPU-aware behavior;
 - `gpu`: requires a suitable GPU/driver/toolkit;
 - `hardware`: cameras, headset, or other physical device;
-- `slow`: unsuitable for normal per-change feedback.
+- `slow`: unsuitable for normal per-change feedback;
+- `player`: requires the optional Qt/OpenGL player and a display.
 
-Root collection contains only the lightweight core, headless visualization,
-and validation-script suites. Optional Open3D and Torch suites use the explicit
-commands above. Several research scripts are named `test.py`,
-`decoder_test.py`, or `model_test.py` but perform local-dataset/GPU experiments
-and must not be collected by default. Rename or configure them only after
-preserving their intended commands.
+Root collection contains the public core, codec contracts, I/O, Torch helpers,
+headless visualization, examples, and validation-script suites named in
+`pyproject.toml`. Optional dependencies are skipped unless installed; focused
+Open3D and Torch commands are shown above. Several research scripts are named
+`test.py`, `decoder_test.py`, or `model_test.py` but perform local-dataset/GPU
+experiments and must not be collected by default. Rename or configure them only
+after preserving their intended commands.
 
 For a new feature, cover at least:
 

--- a/docs/handbook/v0.2-dev/implementation-status.md
+++ b/docs/handbook/v0.2-dev/implementation-status.md
@@ -5,11 +5,14 @@ The detailed [component register](status.md) is the immutable audit of commit
 and the [90-day roadmap](roadmap.md). It must be updated when roadmap work is
 merged; planned or locally reverted work must not be reported as implemented.
 
+Last reconciled with `94ae714` (`origin/main`) on 2026-08-27. Test counts below
+retain their own earlier snapshot date.
+
 ## Current platform graph
 
 ```mermaid
 flowchart TB
-    Handbook["v0.2-dev handbook<br/>LOCAL DRAFT"]
+    Handbook["v0.2-dev handbook<br/>MERGED SOURCE"]
     P0["Packaging / CI / governance<br/>VERIFIED-PARTIAL"]
     Core["Core model<br/>VERIFIED-PARTIAL"]
     Examples["Public I/O / reference codec / viewer<br/>VERIFIED-PARTIAL"]
@@ -26,12 +29,12 @@ flowchart TB
 
 | Work item | Current state | Next evidence required |
 | --- | --- | --- |
-| Versioned handbook | Source and root README link prepared; Wiki export committed locally with validated links | Initialize the enabled GitHub Wiki, push the prepared export, review, and merge this branch |
-| Explicit lightweight package allowlist | Implemented for exactly seven packages; namespace discovery removed | Keep the provenance and archive assertions required in CI |
-| Exact distribution assertion | Wheel and source archive inventories pass locally | Confirm the packaging job on Blacksmith for this pull request |
+| Versioned handbook | Source and root README link are merged; local links are validated | Decide whether to publish and maintain a separate Wiki copy |
+| Explicit lightweight package allowlist | Implemented for exactly eight packages; namespace discovery removed | Keep the provenance and archive assertions required in CI |
+| Exact distribution assertion | Wheel and source archive inventories pass locally and are required by CI | Record any release-boundary change in the ledger and archive assertions |
 | Third-party/provenance ledger | Root ledger covers the high-risk research, data, model, binary, paper, and submodule areas | Resolve each entry with immutable provenance and reviewed distribution terms |
 | License/distribution gate | Supported release workflow fails while `BLOCK` entries remain | Resolve TVMC, QNDF, copied-upstream, binary, dataset, checkpoint, and paper scope |
-| Continuous integration | Blacksmith-backed GitHub Actions workflow, Python/Open3D matrices, packaging smoke test, links, syntax, provenance, and release checks prepared | Verify all GitHub checks on this pull request |
+| Continuous integration | Blacksmith-backed GitHub Actions workflow on `main` contains Python/Open3D matrices, research-codec CPU contracts, packaging smoke tests, links, syntax, provenance, and release checks | Keep required jobs green and record any runner-specific exceptions |
 | CodeRabbit | Repository features disabled in version-controlled configuration | Remove this repository from the CodeRabbit GitHub App installation to revoke access |
 | Protected merge policy | No repository ruleset recorded at the audit point | Require the verified CI checks after their exact GitHub check names exist |
 
@@ -45,12 +48,18 @@ flowchart TB
 - Independent codec and reconstruction research trees, with public adapters
   for KLT, N4MC, QNDF/QNDF-int8, temporal mesh experiments, and V-Mesh; they
   do not yet form a complete end-to-end application.
+- The restored `gs_tools` directory holds the shared Gaussian environment,
+  rasterizers, GLM, simple-knn, and SIBR viewer used by QUEEN and 3DGStream. It
+  remains in Ryan's ownership lane and outside the lightweight distribution.
+- Both the pinned MPEG V-DMC reference tree and the `faster_vdmc` fork are
+  registered as submodules; their public adapters require configured native
+  executables and neither clears the release-provenance block.
 - Checksum-based artifact-fetching policy and the component-specific mechanics
   explicitly identified in the handbook as worth preserving.
 
 ## Local verification snapshot
 
-Snapshot taken 2026-08-25 on macOS:
+Latest recorded test snapshot taken 2026-08-25 on macOS:
 
 - A clean Python 3.13 environment installed with `uv pip install -e '.[dev]'`
   and run with `python -m pytest -q` reports 233 passed and 26 explicit
@@ -73,15 +82,16 @@ Draco, and V-Mesh adapters, and the public Qt visualizer. It does **not** contai
 TVMC/TSMC shared adapters, an RGB-D finite replay adapter, or a live-stream
 contract implementation. These remain roadmap items.
 
-Blacksmith is an automation surface, not evidence by itself. Its pull-request
-results must still prove the tests, packaging boundary, provenance containment,
-and release block implemented in this branch.
+Blacksmith is an automation surface, not evidence by itself. Its workflow
+results must prove the tests, packaging boundary, provenance containment, and
+release block for each protected change.
 
 ## Immediate order of work
 
-1. Initialize and publish the enabled Wiki, then review and merge the handbook.
-2. Remove this repository from the CodeRabbit GitHub App installation.
-3. Verify the complete Blacksmith matrix on the pull request.
-4. Configure protected-merge checks using the stable check names from that run.
-5. Resolve the provenance ledger's `BLOCK` entries; do not publish meanwhile.
-6. Begin P1 only after P0 acceptance criteria are green.
+1. Resolve the provenance ledger's `BLOCK` entries; do not publish meanwhile.
+2. Record and require the stable CI check names in protected-merge rules.
+3. Remove this repository from the CodeRabbit GitHub App installation.
+4. Decide whether the repository handbook or a separately maintained Wiki is
+   the public source of truth.
+5. Finish the public metrics and USD contracts, then build the first complete
+   reference application in `apps/`.

--- a/docs/handbook/v0.2-dev/platform.md
+++ b/docs/handbook/v0.2-dev/platform.md
@@ -1,9 +1,9 @@
 # Core, I/O, OpenUSD, and metrics
 
-This chapter distinguishes the supported v0.2-dev core from working example
-code and from the next public APIs. That distinction matters when you build a
-codec adapter: importing an example by modifying `sys.path` is not a stable
-platform interface.
+This chapter records the supported core, example code, and planned public APIs
+at commit `96b8c7b`. It is historical. See
+[current implementation status](implementation-status.md) and the root README
+for APIs promoted after the audit.
 
 ## Public core model
 
@@ -38,9 +38,8 @@ The object is structurally immutable, but its NumPy buffers are not forced
 read-only. Canonical arrays may be shared zero-copy with the caller. Preserve
 this policy unless a measured need and migration plan justify changing it.
 
-The current gap is integer attribute narrowing: indices are range-checked before
-conversion, but generic integer attributes also need an explicit `int32` range
-check so a large value cannot wrap silently.
+At the audited revision, generic integer attributes lacked an explicit `int32`
+range check. That check and its boundary tests have since been implemented.
 
 ### Frame
 
@@ -73,7 +72,7 @@ constant topology, vertex count, and correspondence unless the provider makes a
 more specific declaration; `UNKNOWN` correctly returns `None` when evidence is
 insufficient.
 
-## Working example I/O
+## Example I/O at the audited revision
 
 `examples/visualization/frame_sources.py` currently provides the one-call loader:
 
@@ -104,14 +103,16 @@ Important limitations:
   sorts on 9 and can silently misalign comparisons.
 - zero-face geometry stands in for point clouds because core has no point type.
 
-The P1 public interface is:
+The planned P1 public interface was:
 
 ```python
 open4d.io.open_sequence(path, fps=None) -> Sequence
 open4d.io.write_usd_container(path, frames, ...) -> pathlib.Path
 ```
 
-Examples should become thin clients of those functions. Promotion must keep
+`open4d.io.open_sequence` and the mesh-file writers now exist. USD remains
+example-local. Examples should become thin clients of public functions;
+promotion must keep
 construction lazy, add cleanup and malformed-source tests, and use actionable
 optional-dependency errors.
 

--- a/docs/handbook/v0.2-dev/reconstruction-streaming.md
+++ b/docs/handbook/v0.2-dev/reconstruction-streaming.md
@@ -135,11 +135,13 @@ contract through the old raw transport by default.
 
 ## Gaussian splats: Ryan's ownership boundary
 
-The audited tree contains full sibling directories
+The following describes commit `96b8c7b`, not the current tree. The audited
+tree contained full sibling directories
 `open4d/reconstruction/queen/` and `open4d/reconstruction/3dgstream/`.
-`open4d/reconstruction/gs_tools/` is only a placeholder README. Documentation
-that says QUEEN and 3DGStream live under `gs_tools` is stale; the deleted design
-must not be recreated without Ryan's agreement.
+`open4d/reconstruction/gs_tools/` was only a placeholder README. Documentation
+that said QUEEN and 3DGStream lived under `gs_tools` was stale at that revision.
+After the audit, `gs_tools` was restored as their shared environment and tooling
+directory. The ownership and review boundary below still applies.
 
 ### QUEEN
 

--- a/docs/handbook/v0.2-dev/repository-map.md
+++ b/docs/handbook/v0.2-dev/repository-map.md
@@ -3,6 +3,11 @@
 This map describes what is physically present at the audited revision and how
 each area should align with the platform.
 
+It is not a current tree listing. In particular, `gs_tools` was restored after
+the audit and public I/O, visualization, and codec adapters were added. See
+[current implementation status](implementation-status.md) and the root README
+for the live inventory.
+
 ## Top-level map
 
 ```text
@@ -67,7 +72,7 @@ of each method.
 | MRD3 | continuous Draco/JPEG mesh frames | successive reconstruction results | live frame messages and receive statistics | label experimental; supersede only after live contract |
 | QUEEN | trains and quantizes dynamic 3D Gaussians for free-viewpoint video | calibrated multi-view images/COLMAP | initial/delta Gaussian artifacts and rendered views | Ryan-owned handoff contract only |
 | 3DGStream | initial 3DGS plus per-frame neural transformation cache/new Gaussians | calibrated multi-view images and initial 3DGS | per-frame NTC/new Gaussian data and renders | Ryan-owned handoff contract only |
-| `gs_tools` | currently a one-heading placeholder | none | none | correct stale descriptions; do not resurrect deleted design |
+| `gs_tools` | one-heading placeholder at the audit | none | none | historical state; the directory was restored after the audit |
 
 See [reconstruction and streaming](reconstruction-streaming.md) for data and
 protocol details.

--- a/docs/handbook/v0.2-dev/roadmap.md
+++ b/docs/handbook/v0.2-dev/roadmap.md
@@ -1,5 +1,9 @@
 # Dependency-ordered roadmap and TODO list
 
+Checklist status was reconciled with the repository on 2026-08-27. A checked
+box means the named repository change exists; it does not waive the release
+block or make a research pipeline complete.
+
 This list is ordered by dependency and risk, not by how exciting the demo looks.
 P0 prevents unsafe releases and false status claims; P1 creates reusable
 contracts; P2 proves them on a CPU codec; P3 applies them to temporal capture
@@ -26,31 +30,31 @@ flowchart LR
 
 - [x] Publish this versioned `v0.2-dev` handbook and link it from the root
   README.
-- [ ] Replace namespace auto-discovery with an explicit lightweight package
+- [x] Replace namespace auto-discovery with an explicit lightweight package
   allowlist.
-- [ ] Build a clean wheel and assert its exact file list; ensure no research
+- [x] Build a clean wheel and assert its exact file list; ensure no research
   codec, Gaussian, dataset, paper, or Unity binary ships accidentally.
-- [ ] Create a root third-party/provenance ledger covering code, submodules,
+- [x] Create a root third-party/provenance ledger covering code, submodules,
   models, datasets, binaries, papers, copied helpers, and licenses.
 - [ ] Resolve TVMC, QNDF, copied-upstream, binary, and dataset distribution
   scope. Block releases until this gate passes.
-- [ ] Record Ryan's ownership of QUEEN/3DGStream in contribution/ownership
+- [x] Record Ryan's ownership of QUEEN/3DGStream in contribution/ownership
   guidance and exclude those paths from unrelated refactors.
 
 ### CI and tests
 
-- [ ] Add Python 3.10–3.13 core build/install/import/test jobs.
-- [ ] Add Python 3.10–3.12 Open3D jobs.
-- [ ] Add clean packaging smoke tests and exact wheel-content checks.
-- [ ] Add Python syntax, shell syntax, Markdown-link, provenance, and license
+- [x] Add Python 3.10–3.13 core build/install/import/test jobs.
+- [x] Add Python 3.10–3.12 Open3D jobs.
+- [x] Add clean packaging smoke tests and exact wheel-content checks.
+- [x] Add Python syntax, shell syntax, Markdown-link, provenance, and license
   validation.
-- [ ] Configure root pytest markers: `cpu`, `open3d`, `torch`, `gpu`,
-  `hardware`, and `slow`.
-- [ ] Keep research experiment scripts out of default test collection without
+- [x] Configure root pytest markers: `cpu`, `open3d`, `torch`, `gpu`,
+  `hardware`, `slow`, and `player`.
+- [x] Keep research experiment scripts out of default test collection without
   deleting their documented workflows.
-- [ ] Restore comprehensive Frame/provider/Sequence/view tests: empty,
+- [x] Restore comprehensive Frame/provider/Sequence/view tests: empty,
   timestamps, slices, topology, metadata, cleanup, laziness, failures.
-- [ ] Reject integer named attributes outside the canonical `int32` range.
+- [x] Reject integer named attributes outside the canonical `int32` range.
 
 ### P0 acceptance
 

--- a/docs/handbook/v0.2-dev/status.md
+++ b/docs/handbook/v0.2-dev/status.md
@@ -104,15 +104,15 @@ flowchart TB
 - **Audit:** `96b8c7b`, 2026-08-13.
 - **Research/upstream capability:** lazy folders/single files for OBJ, PLY, USD,
   and optional trimesh formats.
-- **Open4D integration:** local mesh files and folders are public through
-  `open4d.io`; USD remains example-local.
-- **Verification:** public I/O has focused CPU tests; USD retains example tests.
+- **Open4D integration:** returns the core `Sequence`, but the API lives under
+  `examples/visualization`, not `open4d.io`.
+- **Verification:** included in the recorded 106-test Python 3.12 run.
 - **Input/output:** mesh directory or file -> lazy `Sequence[Frame[TriangleMesh]]`.
 - **Owner lane:** shared platform I/O.
-- **Known blockers:** filename-last-number ordering remains a convention;
-  limited OBJ/PLY attributes and the point-cloud placeholder remain.
-- **Smallest useful next contribution:** promote the USD backend with explicit
-  schema, point-cloud, and lossy-write decisions.
+- **Known blockers:** filename-last-number ordering trap, mixed-format skipping,
+  limited OBJ/PLY attributes, point-cloud placeholder, no supported public API.
+- **Smallest useful next contribution:** promote `open_sequence` with its
+  registry/providers to `open4d.io` behind parity and cleanup tests.
 
 ### Example OpenUSD container — `VERIFIED-PARTIAL`
 

--- a/docs/python-api-plan.md
+++ b/docs/python-api-plan.md
@@ -44,7 +44,7 @@ with open_sequence("capture/", fps=30.0) as sequence:
     mesh = sequence[0].geometry
 ```
 
-The proposed first public surface is:
+The implemented mesh-I/O surface is:
 
 ```python
 def open_sequence(
@@ -68,7 +68,6 @@ def write_sequence(
     format: str | None = None,
     overwrite: bool = False,
     allow_lossy: bool = False,
-    options: Mapping[str, object] | None = None,
 ) -> Path: ...
 
 def available_formats() -> tuple[FormatInfo, ...]: ...
@@ -279,6 +278,9 @@ be updated alongside the new package.
 
 ## Implementation slices
 
+Slices 1 and the manifested-directory portion of slice 3 are implemented.
+Public USD, TVMC/RGB-D providers, and representation expansion remain open.
+
 ### Slice 1: public mesh loading
 
 - Move the built-in OBJ/PLY and folder providers out of
@@ -388,19 +390,16 @@ wall-clock timing runs separately from memory tracing to avoid instrumentation
 bias. These reference-codec measurements are in-process, and source parsing is
 reported separately. V-DMC is a separate native-process backend.
 
-## Questions to settle with the first implementation
+## Remaining design questions
 
-1. Should the manifest filename be fixed (for example,
-   `open4d.sequence.json`) or discovered by schema content?
-2. Which coordinate-system declarations are required in v1, and which may be
+1. Which coordinate-system declarations are required in v1, and which may be
    unknown rather than guessed?
-3. Should `write_sequence` initially expose only USD, or also a manifested
-   OBJ/PLY directory writer for a dependency-free round trip?
-4. Does `inspect_sequence` guarantee zero geometry decode, or report an
-   `inspection_cost` capability for formats that require it?
-5. Which format-specific settings have proved common enough to promote out of
+2. Which format-specific settings have proved common enough to promote out of
    `options` into typed arguments after the first two readers?
 
-These questions can be answered with the small OBJ/PLY and USD slices. They do
-not need to block the central architecture: storage remains replaceable,
-providers remain lazy, and `Sequence` remains the Python contract.
+The manifest name is now fixed as `open4d.sequence.json`, dependency-free
+manifested OBJ/PLY directory writing is implemented, and
+`inspect_sequence` guarantees metadata inspection without geometry decode for
+the supported mesh storage forms. The remaining questions do not block the
+central architecture: storage remains replaceable, providers remain lazy, and
+`Sequence` remains the Python contract.

--- a/docs/sequence-design.md
+++ b/docs/sequence-design.md
@@ -1,8 +1,13 @@
 # Shared temporal geometry design
 
-For the proposed public loading, format detection, directory manifest, and
-writer API built on this model, see [Python API plan for heterogeneous 3D
-sequences](python-api-plan.md).
+Status: historical design record. `TriangleMesh`, `Frame`, `FrameProvider`, and
+`Sequence` are implemented, as are public mesh I/O and selected codec adapters.
+Use the root README and the handbook's current implementation status for the
+live feature list.
+
+For the implemented public loading, format detection, directory manifest, and
+writer API, plus the remaining design work, see the
+[Python API plan for heterogeneous 3D sequences](python-api-plan.md).
 
 ## Purpose
 
@@ -20,8 +25,8 @@ value and provider boundaries before codec APIs are changed.
 
 ## Existing representations
 
-The repository currently has no shared frame value. The main paths use these
-representations:
+When this design was written, the repository had no shared frame value. The
+research paths used these representations:
 
 | Path | Geometry and attributes | Time and sequence state | Topology |
 |---|---|---|---|

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-# One environment for every Open4D codec.
+# Shared environment for Open4D codec Python stages.
 #
 #   conda env create -f environment.yml
 #   conda activate open4d

--- a/open4d/codecs/README.md
+++ b/open4d/codecs/README.md
@@ -1,8 +1,9 @@
 # Codecs
 
 This directory contains Open4D's compression implementations and reference
-codec integrations. Each codec owns its environment, build instructions, data,
-and generated outputs; consult the codec's README before running it.
+codec integrations. The Python codecs share the root Python 3.12 dependency
+set, while each codec owns its native build instructions, optional GPU extras,
+data, and generated outputs. Consult the codec's README before running it.
 
 The directory names are stable, lowercase identifiers:
 

--- a/open4d/codecs/draco/README.md
+++ b/open4d/codecs/draco/README.md
@@ -35,10 +35,13 @@ This produces `draco/build/draco_encoder` and `draco/build/draco_decoder`. If yo
 already built Draco elsewhere (e.g. `tvmc/draco/build`), point the scripts at it
 with `--draco_bin_dir` or `export DRACO_BIN_DIR=/path/to/build`.
 
-For the Python evaluation dependencies:
+For the Python evaluation dependencies, use the repository-wide codec
+environment:
 
 ```bash
-python -m pip install -r requirements.txt
+conda env create -f ../../../environment.yml
+conda activate open4d
+python -m pip install -e ../../..
 ```
 
 ## Usage

--- a/open4d/codecs/klt/README.md
+++ b/open4d/codecs/klt/README.md
@@ -37,9 +37,10 @@ KLT/
 ## Setup
 
 ```bash
-python -m venv .venv && source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
+conda env create -f ../../../environment.yml
+conda activate open4d
+python -m pip install -e ../../..
+python -m pip install -r ../../../requirements-gpu.txt  # kaolin, for evaluation
 ```
 
 `kaolin`, `point_cloud_utils`, and `pymeshlab` are only needed for the optional

--- a/open4d/codecs/qndf/README.md
+++ b/open4d/codecs/qndf/README.md
@@ -16,12 +16,13 @@ conda env create -f ../../../environment.yml   # or: conda activate open4d
 pip install -e ../../..
 ```
 
-Step 3. Install `dahuffman` and `tqdm` using `pip`
+Step 3. No additional Python install is required; `dahuffman` and `tqdm` are in
+the shared codec environment.
 
 Step 4. Create `objs_original/` and place the `.obj` files to be compressed in
-it. No meshes ship with the repository — this codec's `.gitignore` excludes
-`*.obj`, so source your own or point `--source-dir` at a vendored sequence as
-the basketball recipe below does.
+it. QNDF does not ship its own input meshes — this codec's `.gitignore` excludes
+`*.obj` — so source your own or point `--source-dir` at another repository
+fixture, such as the TVMC basketball sequence used below.
 
 Step 5. Run:
 
@@ -47,7 +48,7 @@ vertices can be restored to the input coordinate system.
 Run the complete basketball sequence with:
 
 ```bash
-conda activate pytorch
+conda activate open4d
 mkdir -p outputs/basketball_sequence_qndf
 nohup python run_basketball_sequence.py \
   --source-dir ../tvmc/arap-volume-tracking/data/basketball_player \

--- a/open4d/codecs/tvmc/README.md
+++ b/open4d/codecs/tvmc/README.md
@@ -1,7 +1,8 @@
 # TVMC Quick Start
 
-TVMC supports Homebrew macOS and Ubuntu Linux. It requires Python 3.8–3.11,
-CMake, Git, and the .NET 10 SDK.
+TVMC supports Homebrew macOS and Ubuntu Linux. It uses Open4D's shared Python
+3.12 codec environment and additionally requires CMake, Git, and the .NET 10
+SDK.
 
 ## 1. Install system dependencies
 
@@ -11,21 +12,20 @@ Install [Homebrew](https://brew.sh/) if it is not already available, then run:
 
 ```bash
 brew update
-brew install cmake python@3.11 dotnet git
+brew install cmake python@3.12 dotnet git
 ```
 
 Verify the required tools:
 
 ```bash
-python3.11 --version
+python3.12 --version
 dotnet --version
 cmake --version
 ```
 
 ### Ubuntu Linux
 
-Ubuntu 22.04 includes Python 3.10, which is supported by TVMC. Install the
-system packages:
+On Ubuntu 24.04, install the system packages:
 
 ```bash
 sudo apt update
@@ -54,7 +54,21 @@ dotnet --version
 cmake --version
 ```
 
-## 2. Enter the TVMC directory
+## 2. Create the shared Python environment
+
+From the Open4D repository root:
+
+```bash
+conda env create -f environment.yml
+conda activate open4d
+python -m pip install -e .
+```
+
+This is the same Python 3.12 dependency set used by the other codecs. TVMC's
+local `requirements.txt` mirrors the relevant pins but is not a second supported
+dependency baseline.
+
+## 3. Enter the TVMC directory
 
 From the Open4D repository root:
 
@@ -64,17 +78,19 @@ cd open4d/codecs/tvmc
 
 The ten basketball sample meshes are included in the repository.
 
-## 3. Set up TVMC
+## 4. Build TVMC's native dependencies
 
 Run the setup script once:
 
 ```bash
-./setup.sh
+./setup.sh --build-only
 ```
 
-This creates `.venv`, installs the Python packages, builds the .NET projects, initializes Draco, and builds the Draco encoder and decoder.
+This builds the .NET projects, initializes Draco, and builds the Draco encoder
+and decoder. Running `./setup.sh` without `--build-only` remains a convenience
+for creating a component-local `.venv`, but it uses the same Python 3.12 pins.
 
-## 4. Run the pipeline
+## 5. Run the pipeline
 
 ```bash
 ./run_pipeline.sh basketball
@@ -143,15 +159,13 @@ TVMC/basketball_player_outputs/metrics.json
 
 ## View the outputs
 
-TVMC produces a sequence of decoded OBJ meshes. From `open4d/codecs/tvmc`, use the
-Open4D OBJ-sequence player to view them:
+TVMC produces a sequence of decoded OBJ meshes. From `open4d/codecs/tvmc`, use
+the public Open4D sequence viewer:
 
 ```bash
-.venv/bin/python ../tsmc/tsmc/player.py \
-  --mesh-dir TVMC/basketball_player_outputs \
-  --pattern 'decoded_*.obj' \
-  --fps 10 \
-  --loop
+python -m pip install -e '../../..[player]'
+python ../../../examples/visualization/visualize_sequence.py \
+  TVMC/basketball_player_outputs/ --fps 10
 ```
 
 ### Outputs generated on an SSH machine
@@ -170,11 +184,10 @@ Then enter the local TVMC directory and launch the player:
 ```bash
 cd /path/to/local/Open4D/open4d/codecs/tvmc
 
-.venv/bin/python ../tsmc/tsmc/player.py \
-  --mesh-dir TVMC/basketball_player_outputs \
-  --pattern 'decoded_*.obj' \
-  --fps 10 \
-  --loop
+python -m pip install -e '../../..[player]'
+python ../../../examples/visualization/visualize_sequence.py \
+  TVMC/basketball_player_outputs/ --fps 10
 ```
 
-Run `./setup.sh` in the local TVMC directory first if `.venv` does not exist.
+The root Open4D viewer is documented in the project README and does not require
+a TVMC-local `.venv`.

--- a/open4d/codecs/tvmc/setup.sh
+++ b/open4d/codecs/tvmc/setup.sh
@@ -44,16 +44,16 @@ fi
 if [[ "$BUILD_ONLY" -eq 0 ]]; then
   PYTHON_BIN="${PYTHON:-}"
   if [[ -z "$PYTHON_BIN" ]]; then
-    for candidate in python3.10 python3.11 python3.9 python3.8 python3 python; do
+    for candidate in python python3.12 python3; do
       if command -v "$candidate" >/dev/null 2>&1; then
         PYTHON_BIN="$candidate"
         break
       fi
     done
   fi
-  [[ -n "$PYTHON_BIN" ]] || { echo "error: Python 3.8-3.11 is required" >&2; exit 1; }
-  "$PYTHON_BIN" -c 'import sys; raise SystemExit(not ((3, 8) <= sys.version_info[:2] < (3, 12)))' || {
-    echo "error: Open3D 0.18 requires Python 3.8-3.11; found $($PYTHON_BIN --version)" >&2
+  [[ -n "$PYTHON_BIN" ]] || { echo "error: Python 3.12 is required" >&2; exit 1; }
+  "$PYTHON_BIN" -c 'import sys; raise SystemExit(sys.version_info[:2] != (3, 12))' || {
+    echo "error: the shared codec environment requires Python 3.12; found $($PYTHON_BIN --version)" >&2
     exit 1
   }
   if [[ ! -x "$ROOT/.venv/bin/python" && ! -x "$ROOT/.venv/Scripts/python.exe" ]]; then
@@ -64,6 +64,10 @@ if [[ "$BUILD_ONLY" -eq 0 ]]; then
   else
     VENV_PYTHON="$ROOT/.venv/bin/python"
   fi
+  "$VENV_PYTHON" -c 'import sys; raise SystemExit(sys.version_info[:2] != (3, 12))' || {
+    echo "error: $ROOT/.venv is not Python 3.12; remove it and rerun setup" >&2
+    exit 1
+  }
   "$VENV_PYTHON" -m pip install --upgrade pip
   "$VENV_PYTHON" -m pip install -r "$ROOT/requirements.txt"
 fi

--- a/requirements-codecs.txt
+++ b/requirements-codecs.txt
@@ -1,4 +1,4 @@
-# The shared pip set for every Open4D codec. Installed by the root
+# The shared pip set for Open4D codec Python stages. Installed by the root
 # environment.yml; also usable on its own inside an existing Python 3.12 venv.
 #
 # These are direct dependencies only. The per-codec environment.yml files used to

--- a/scripts/tests/test_tvmc_setup.py
+++ b/scripts/tests/test_tvmc_setup.py
@@ -1,0 +1,21 @@
+"""Keep TVMC's setup entry point aligned with the shared codec environment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.cpu
+
+
+def test_tvmc_setup_accepts_the_repository_python_version():
+    root = Path(__file__).resolve().parents[2]
+    setup = (root / "open4d/codecs/tvmc/setup.sh").read_text(encoding="utf-8")
+
+    assert "python3.12" in setup
+    assert "Python 3.8-3.11 is required" not in setup
+    assert "Open3D 0.18 requires Python 3.8-3.11" not in setup
+    assert '"$VENV_PYTHON" -c' in setup
+    assert "remove it and rerun setup" in setup


### PR DESCRIPTION
# What changed

Reconciles the root guides, historical handbook, live status, roadmap, codec setup instructions, and repository inventories with the current implementation; TVMC now follows and validates the shared Python 3.12 codec baseline.

## Verification

- Commands and results: `python3 -m pytest -q` (272 passed, 27 expected skips); Markdown links, provenance containment, shell syntax, and `git diff --check` passed.
- Python, OS, GPU/hardware: Python 3.13.15, macOS 27.0 arm64; no GPU or hardware required.
- Input and output fixture/artifact: no datasets or generated artifacts; one source-inspection regression test for the TVMC setup contract.

## Safety checklist

- [x] Tests cover success, empty input, and relevant failure paths.
- [x] Optional dependencies remain optional and have actionable errors.
- [x] Wheel/sdist boundaries are unchanged or their exact checks were updated.
- [x] `THIRD_PARTY.md` was updated for copied code, data, models, papers, media, binaries, or submodules.
- [x] No credentials, private captures, generated outputs, or local datasets were added.
- [x] Documentation and status claims match verified behavior.

## Remaining limitations

Native codec, GPU, camera, Unity, and provenance-blocked release paths were not executed; their documented support boundaries remain unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open4dfoundation/codesmith/Open4D/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790454586&installation_model_id=432509&pr_number=40&repository=open4dfoundation%2FOpen4D&return_to=https%3A%2F%2Fgithub.com%2Fopen4dfoundation%2FOpen4D%2Fpull%2F40&signature=157d66ed659ce37cb21c7e6d777764519379559c52df9e08c70ff44460433043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->