### PR TITLE
Run OpenUSD regression tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,12 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - name: Install player tier
-        run: python -m pip install -e '.[dev,player]'
+      - name: Install player and OpenUSD tier
+        run: python -m pip install -e '.[dev,player,usd]'
       - name: Test public visualizer and dependency imports
         run: |
           python -c "import PyQt6, pyqtgraph, OpenGL, PIL, open4d.visualization"
+          python -c "from pxr import Usd; print(Usd.GetVersion())"
           python -m pytest open4d/visualization/tests examples/visualization/tests
 
   package:


### PR DESCRIPTION
## Summary

- install the existing `usd` extra in the Python 3.12 visualization tier
- explicitly import `pxr.Usd` so OpenUSD coverage cannot silently skip
- leave the lightweight Python 3.13 core tier unchanged

This completes the CI close-out for issues #22–#27. Their runtime fixes are already on `main` through #39 and `ea871d4`.

## Verification

- `python3 -m pytest -q examples/visualization/tests/test_formats_usd.py examples/visualization/tests/test_frame_sources.py open4d/io/tests/test_sequence_io.py open4d/core/tests/test_dtypes.py` in an isolated `.[dev,usd]` environment — 68 passed
- default `pytest --collect-only` — 297 tests collected, no `integrations/open3d/tests`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open4dfoundation/codesmith/Open4D/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790526808&installation_model_id=432509&pr_number=41&repository=open4dfoundation%2FOpen4D&return_to=https%3A%2F%2Fgithub.com%2Fopen4dfoundation%2FOpen4D%2Fpull%2F41&signature=197975abe4c8c71031318d0e4f56fa0b9ae80580262285ede4dc7ae147e2cb58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->