### PR TITLE
Add unified sequence API and OpenUSD container support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - name: Install I/O tools tier
-        run: python -m pip install -e '.[dev,tools,draco]'
-      - name: Exercise built-in and Trimesh-backed files
+      - name: Install optional I/O tier
+        run: python -m pip install -e '.[dev,tools,draco,usd]'
+      - name: Exercise built-in and optional I/O formats
         run: python -m pytest open4d/io/tests open4d/codec/tests/test_draco.py
       - name: Validate benchmark paths
         run: |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ point-cloud sequences into one open-source research project. In this project,
 ### What works today
 
 - A small Python model for triangle meshes, frames, and finite sequences.
-- Loaders for folders of `.obj` or `.ply` frames, with optional OpenUSD support.
+- One-file OpenUSD and Open4D codec sequences, plus `.obj`/`.ply` import paths.
 - A viewer for inspecting, playing, scrubbing, and exporting mesh sequences.
 - A comparison tool that measures a decoded sequence against its reference and
   displays both under one camera.
@@ -32,16 +32,16 @@ point-cloud sequences into one open-source research project. In this project,
 ### Try the sequence viewer
 
 The lightweight viewer runs on macOS, Linux, and Windows and does not need a
-GPU. Point it at a folder containing one `.obj` or `.ply` mesh per frame:
+GPU. Its normal input is one 4D sequence file:
 
 ```bash
 git clone https://github.com/open4dfoundation/Open4D.git
 cd Open4D
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install -e '.[player]'
-python examples/visualization/visualize_sequence.py /path/to/frames/ --info
-python examples/visualization/visualize_sequence.py /path/to/frames/
+python -m pip install -e '.[player,usd]'
+python examples/visualization/visualize_sequence.py capture.usdc --info
+python examples/visualization/visualize_sequence.py capture.usdc
 ```
 
 On Windows, activate the environment with `.venv\Scripts\activate` instead.
@@ -279,19 +279,24 @@ the Draco baseline codec's own, plus TSMC's and TVMC's — with:
 
 ## Sequence viewer details
 
-The public Python API loads, encodes, decodes, and visualizes finite
-triangle-mesh sequences independently of their supported file formats:
+The public Python API loads, saves, unloads, and visualizes whole finite
+triangle-mesh sequences independently of their storage format:
 
 ```python
-from open4d.codec import decode_sequence, encode_sequence
-from open4d.io import open_sequence
-from open4d.visualization import visualize
+import open4d
 
-sequence = open_sequence("path/to/frames", fps=30)
-artifact = encode_sequence(sequence, "sequence.o4d", codec="lzma")
-decoded = decode_sequence(artifact)
-visualize(decoded, up="y")
+with open4d.load("capture.usdc") as sequence:
+    open4d.save(sequence, "capture.o4d")
+    open4d.visualize(sequence)
+
+# A path can go straight to the lazy viewer; it is closed when the window exits.
+open4d.visualize("capture.o4d")
 ```
+
+`.usd`, `.usda`, `.usdc`, and `.usdz` are OpenUSD interchange containers.
+`.o4d` and the registered codec suffixes are codec artifacts. Both carry whole
+sequences and use the same `Sequence` interface. `open4d.unload(sequence)` is an
+explicit, idempotent alternative to the context manager.
 
 `write_sequence(sequence, "frames/", format="ply")` writes a versioned
 `open4d.sequence.json` beside the frame files, so reopening the directory keeps
@@ -323,7 +328,7 @@ notebook selection with `OPEN4D_NOTEBOOK_DEVICE=mps` when needed.
 
 This API slice standardizes files around `Sequence[Frame[TriangleMesh]]`; it is
 not yet representation-independent. First-class point-cloud, volume, Gaussian,
-USD-sequence, and live-stream values require separate contracts.
+and live-stream values require separate contracts.
 
 Normal CI runs dependency-complete CPU encode/fresh-decode contracts for KLT,
 N4MC, QNDF, and QNDF-int8. The larger two-format Rafa quality/export matrix is
@@ -341,14 +346,14 @@ Playback uses `open4d.visualization`'s PyQt6 window: drag to orbit, scroll to zo
 to scrub, space to pause, left/right to step a frame. `--save out.gif` writes an
 animated GIF through the same renderer.
 
-A viewer source may be one mesh file, a folder holding one mesh file per frame,
-or a single time-sampled USD file. OBJ and PLY need no extra dependency; the
-`[tools]` extra adds OFF, STL, GLB, and glTF, while `[usd]` adds USD files and
-folders. `--info` reports frame count, duration, topology and bounds without
-decoding geometry, which is the quickest way to check a dataset loads.
+A viewer source may be a single OpenUSD or codec sequence file, one mesh file,
+or a folder holding one mesh file per frame. OBJ and PLY need no extra dependency;
+the `[tools]` extra adds OFF, STL, GLB, and glTF, while `[usd]` adds OpenUSD
+sequence files. `--info` reports frame count, timing, and topology without decoding
+geometry, which is the quickest way to check a dataset loads.
 
-The public Python loader handles local mesh files and frame folders in one call;
-frames are decoded on access:
+Frame folders and individual meshes remain supported as import paths; frames
+are decoded on access:
 
 ```python
 from open4d.io import open_sequence
@@ -358,10 +363,7 @@ with open_sequence("path/to/frames", fps=30.0) as sequence:
     mesh = sequence[0].geometry          # TriangleMesh: positions, triangles
 ```
 
-The viewer additionally retains its example-local OpenUSD sequence reader while
-that backend is promoted to the public API.
-
-OpenUSD is the container the example writes. `--pack-usd out.usdc` packs any
+OpenUSD is the public interchange container. `--pack-usd out.usdc` packs any
 source into one compressed `.usdc` file carrying the frame rate, the key-frame
 index, and per-frame streams alongside the geometry:
 

--- a/docs/handbook/v0.2-dev/README.md
+++ b/docs/handbook/v0.2-dev/README.md
@@ -126,13 +126,22 @@ The shared codec environment is Python 3.12 because Open3D 0.19 has no Python
 3.13 wheel. Install a viewer only when you have a graphical session:
 
 ```bash
-python -m pip install -e '.[player]'
-python examples/visualization/visualize_sequence.py path/to/frames --info
+python -m pip install -e '.[player,usd]'
+python examples/visualization/visualize_sequence.py capture.usdc --info
 ```
 
-`open4d.io.open_sequence` now loads local mesh files and frame folders. The
-OpenUSD sequence backend remains under `examples/visualization` pending public
-schema and loss-policy work.
+`open4d.load`, `save`, `unload`, and `visualize` now provide one whole-sequence
+workflow for OpenUSD and codec artifacts. Local mesh files and frame folders
+remain supported import paths through the same loader.
+
+```python
+import open4d
+
+with open4d.load("capture.usdc") as sequence:
+    open4d.save(sequence, "capture.o4d")
+
+open4d.visualize("capture.usdc")
+```
 
 ## How to choose a first contribution
 

--- a/docs/handbook/v0.2-dev/platform.md
+++ b/docs/handbook/v0.2-dev/platform.md
@@ -72,24 +72,27 @@ constant topology, vertex count, and correspondence unless the provider makes a
 more specific declaration; `UNKNOWN` correctly returns `None` when evidence is
 insufficient.
 
-## Example I/O at the audited revision
+## Public sequence I/O
 
-`examples/visualization/frame_sources.py` currently provides the one-call loader:
+Whole-sequence files use the top-level API:
 
 ```python
-from frame_sources import open_sequence
+import open4d
 
-with open_sequence("frames/", fps=30.0) as sequence:
-    frame = sequence[0]
+with open4d.load("capture.usdc") as sequence:
+    open4d.save(sequence, "capture.o4d")
+
+open4d.visualize("capture.usdc")
 ```
 
 Supported sources are:
 
 | Source | Base/extra | Current behavior |
 | --- | --- | --- |
+| `.o4d` and registered codec artifacts | base or codec-specific | lazy whole-sequence decode |
+| one `.usd/.usda/.usdc/.usdz` | `.[usd]` | lazy OpenUSD sequence provider |
 | folder of `.obj`/`.ply` | base NumPy | lazy listing/provider; last filename number controls order |
 | one `.obj`/`.ply` | base NumPy | single fixed frame |
-| folder or one `.usd/.usda/.usdc/.usdz` | `.[usd]` | lazy USD provider |
 | `.off/.stl/.glb/.gltf` | `.[tools]` | trimesh fallback |
 
 Important limitations:
@@ -103,50 +106,36 @@ Important limitations:
   sorts on 9 and can silently misalign comparisons.
 - zero-face geometry stands in for point clouds because core has no point type.
 
-The planned P1 public interface was:
+The public whole-sequence interface is:
 
 ```python
-open4d.io.open_sequence(path, fps=None) -> Sequence
-open4d.io.write_usd_container(path, frames, ...) -> pathlib.Path
+open4d.load(path, fps=None) -> Sequence
+open4d.save(sequence, "capture.usdc") -> pathlib.Path
+open4d.visualize(path_or_sequence)
+open4d.unload(sequence)
 ```
 
-`open4d.io.open_sequence` and the mesh-file writers now exist. USD remains
-example-local. Examples should become thin clients of public functions;
-promotion must keep
-construction lazy, add cleanup and malformed-source tests, and use actionable
-optional-dependency errors.
+The existing `open4d.io` and `open4d.codec` entry points remain available and
+delegate to the same providers and writers. USD construction is lazy, cleanup
+is explicit, and a missing optional dependency reports the exact install extra.
 
 ## OpenUSD container
 
-OpenUSD is the selected primary **offline interchange container**, not a
-compression algorithm. The example writer already creates time-sampled
-`UsdGeom.Mesh` or `UsdGeom.Points` data with:
+OpenUSD is a public **offline interchange container**, not a compression
+algorithm. Schema `open4d.usd-sequence/v1` stores:
 
 - positions and bounds per frame;
 - triangle connectivity once for fixed topology or at key frames;
-- per-vertex display color when present;
-- custom frame index, timestamp, keyframe, vertex-count, and triangle-count
-  streams;
-- stage FPS/time range/up axis and `customLayerData["open4d"]` metadata.
+- RGB/RGBA, normals, vertex and face-varying UVs;
+- typed custom float, integer, and boolean arrays with exact shapes;
+- exact frame indices, timestamps, frame/sequence metadata, and topology
+  declarations;
+- stage FPS/time range and Y/Z up axis.
 
-The example format labels its container metadata version `1`, but it is not yet
-the ratified Open4D schema v1. Known fidelity and validation gaps are:
-
-- normals, UVs, named attributes, materials, and general frame metadata are not
-  round-tripped;
-- the reader places stored frame-index streams into metadata but constructs
-  frames with ordinal indices;
-- the first frame chooses Mesh versus Points, so a later mixed sequence is not
-  rejected explicitly and may lose connectivity;
-- an empty position array fails when the writer calculates min/max extent;
-- any `up_axis` other than `"z"` becomes Y; X is not explicitly rejected;
-- transform, units, and coordinate-frame semantics are not first-class.
-
-Schema v1 must preserve positions, triangles, colors, normals, UVs, named
-attributes, stored timestamps/frame indices, sequence metadata, and topology
-declarations. It must support Y-up and Z-up, reject X-up for now, omit extents
-safely for empty geometry, and reject mixed Mesh/Points sequences rather than
-silently dropping data. Unsupported values must fail explicitly.
+Writes are atomic, empty geometry omits its extent safely, and unsupported
+metadata fails before replacing an existing destination. `.usdc` is the
+recommended compact interchange extension; `.o4d` remains the default lossless
+Open4D codec artifact.
 
 ## Working example metrics
 
@@ -201,10 +190,11 @@ metric improves.
 
 ## Viewers and adapters
 
-The PyQt viewers decode and measure the selected display frames up front, then
-provide orbit, zoom, scrub, stepping, playback, GIF output, fixed sequence-wide
-error colors, and synchronized comparison cameras. Preserve existing comparison
-behavior while moving only stable loader/metric/container code into the package.
+The single-sequence PyQt viewer decodes strided frames on demand through a
+three-frame LRU and schedules one-frame lookahead on the Qt event loop. It
+frames the first displayed geometry instead of scanning the complete sequence.
+The comparison viewer still measures selected frames up front so it can provide
+fixed sequence-wide error colors and synchronized cameras.
 
 The Open3D integration converts Open4D geometry or compatible arrays into an
 Open3D `TriangleMesh` or `PointCloud`, preserving vertex colors/normals. It does

--- a/docs/handbook/v0.2-dev/roadmap.md
+++ b/docs/handbook/v0.2-dev/roadmap.md
@@ -71,11 +71,12 @@ flowchart LR
 
 - [x] Add `open4d.io.open_sequence(path, fps=None) -> Sequence` for local mesh
   files and frame folders.
-- [ ] Add `open4d.io.write_usd_container(path, frames, ...) -> Path`.
+- [x] Add public whole-sequence OpenUSD writing through `open4d.save` and
+  `open4d.io.write_sequence`.
 - [ ] Add `open4d.metrics.compare_meshes(...)`.
 - [ ] Add `open4d.metrics.compare_sequences(..., allow_truncate=False)`.
 - [x] Keep the base NumPy-only and lazily load SciPy/OpenUSD/Open3D/viewers.
-- [ ] Convert examples into thin clients of the public functions.
+- [x] Convert sequence loading and USD example code into thin public-API clients.
 
 ### Correctness and interchange
 
@@ -84,10 +85,10 @@ flowchart LR
   frame indices.
 - [ ] Publish metric identifier `open4d.vertex-nearest/v1` and clearly label
   vertex-set, non-area-weighted limitations.
-- [ ] Ratify OpenUSD schema v1 as primary offline interchange.
-- [ ] Round-trip positions, triangles, colors, normals, UVs, named attributes,
+- [x] Ratify `open4d.usd-sequence/v1` as offline interchange.
+- [x] Round-trip positions, triangles, colors, normals, UVs, named attributes,
   timestamps, frame indices, sequence metadata, and topology declarations.
-- [ ] Support Y-up/Z-up, reject X-up, reject mixed Mesh/Points, and handle empty
+- [x] Support Y-up/Z-up, reject X-up, retain zero-face frames, and handle empty
   extents explicitly.
 - [ ] Add a generated or redistributable two-to-three-frame fixture.
 - [ ] Implement and validate `open4d.run-manifest/v1`.

--- a/docs/handbook/v0.2-dev/status.md
+++ b/docs/handbook/v0.2-dev/status.md
@@ -102,8 +102,8 @@ flowchart TB
 ### Example mesh/folder loaders — `VERIFIED-PARTIAL`
 
 - **Audit:** `96b8c7b`, 2026-08-13.
-- **Research/upstream capability:** lazy folders/single files for OBJ, PLY, USD,
-  and optional trimesh formats.
+- **Research/upstream capability:** lazy folders/single files for OBJ, PLY, and
+  optional trimesh formats, plus time-sampled USD sequence files.
 - **Open4D integration:** `open4d.load` and `open4d.io.open_sequence` return the
   shared lazy `Sequence`.
 - **Verification:** public I/O and unified-dispatch tests cover lazy imports,

--- a/docs/handbook/v0.2-dev/status.md
+++ b/docs/handbook/v0.2-dev/status.md
@@ -104,31 +104,28 @@ flowchart TB
 - **Audit:** `96b8c7b`, 2026-08-13.
 - **Research/upstream capability:** lazy folders/single files for OBJ, PLY, USD,
   and optional trimesh formats.
-- **Open4D integration:** returns the core `Sequence`, but the API lives under
-  `examples/visualization`, not `open4d.io`.
-- **Verification:** included in the recorded 106-test Python 3.12 run.
+- **Open4D integration:** `open4d.load` and `open4d.io.open_sequence` return the
+  shared lazy `Sequence`.
+- **Verification:** public I/O and unified-dispatch tests cover lazy imports,
+  manifests, and lifecycle behavior.
 - **Input/output:** mesh directory or file -> lazy `Sequence[Frame[TriangleMesh]]`.
 - **Owner lane:** shared platform I/O.
-- **Known blockers:** filename-last-number ordering trap, mixed-format skipping,
-  limited OBJ/PLY attributes, point-cloud placeholder, no supported public API.
-- **Smallest useful next contribution:** promote `open_sequence` with its
-  registry/providers to `open4d.io` behind parity and cleanup tests.
+- **Known blockers:** limited OBJ/PLY attributes and the point-cloud placeholder.
 
-### Example OpenUSD container — `VERIFIED-PARTIAL`
+### Public OpenUSD container — `VERIFIED`
 
 - **Audit:** `96b8c7b`, 2026-08-13.
 - **Research/upstream capability:** reads/writes time-sampled mesh or points
   stages, topology keyframes, colors, timing streams, and layer metadata.
-- **Open4D integration:** example provider returns `Sequence`; writer consumes
-  frames, but no ratified public schema/API exists.
-- **Verification:** USD behavior is represented in visualization tests; exact
-  supported-field round-trip is not complete.
+- **Open4D integration:** top-level and `open4d.io` APIs read and write the
+  ratified `open4d.usd-sequence/v1` schema.
+- **Verification:** `.usda`, `.usdc`, and `.usdz` golden round trips cover all
+  current mesh fields, typed attributes, identity, timing, metadata, and
+  declarations.
 - **Input/output:** frames or USD -> `.usd/.usda/.usdc/.usdz` or `Sequence`.
 - **Owner lane:** shared platform I/O/interchange.
-- **Known blockers:** normals/UVs/attributes/metadata fidelity, original index
-  restoration, mixed Mesh/Points handling, empty extent, and X-up validation.
-- **Smallest useful next contribution:** write schema-v1 golden tests for every
-  supported field plus explicit failure tests for mixed kinds/X-up.
+- **Known blockers:** transforms, units, materials, and a first-class point-cloud
+  representation remain separate contracts.
 
 ### Example comparison metrics — `VERIFIED-PARTIAL`
 

--- a/docs/python-api-plan.md
+++ b/docs/python-api-plan.md
@@ -1,9 +1,9 @@
 # Python API plan for heterogeneous 3D sequences
 
-Status: implementation in progress. Mesh loading and geometry-only file export
-are implemented. Directory exports use `open4d.sequence.json` to preserve frame
-identity, timing, metadata, and topology declarations. USD promotion, richer
-manifest fields, additional representations, and plugins remain proposals.
+Status: implementation in progress. Unified top-level load/save/unload/view,
+mesh imports, directory manifests, codec-artifact dispatch, and public OpenUSD
+schema v1 are implemented. Additional representations and plugins remain
+proposals.
 
 ## The central decision
 
@@ -34,15 +34,19 @@ core, in `open4d.io`; file-format details should not leak into `Sequence`.
 
 ## User-facing API
 
-The common path should remain one call:
+The common path is one whole-sequence call:
 
 ```python
-from open4d.io import open_sequence
+import open4d
 
-with open_sequence("capture/", fps=30.0) as sequence:
+with open4d.load("capture.usdc") as sequence:
     print(len(sequence), sequence.duration, sequence.topology)
-    mesh = sequence[0].geometry
+    open4d.visualize(sequence)
+    open4d.save(sequence, "capture.o4d")
 ```
+
+Frame directories and static mesh files remain import sources accepted by
+`open4d.load`; OpenUSD and codec artifacts are the normal retained 4D forms.
 
 The implemented mesh-I/O surface is:
 
@@ -291,13 +295,13 @@ Public USD, TVMC/RGB-D providers, and representation expansion remain open.
 - Test static files, numbered directories, missing timing, mixed-directory
   ambiguity, malformed frames, and optional-dependency messages.
 
-### Slice 2: USD round trip
+### Slice 2: USD round trip — implemented
 
 - Move the existing USD reader/writer behind the public registry.
-- Ratify the USD schema described in the roadmap.
+- Ratify `open4d.usd-sequence/v1`.
 - Round-trip every supported mesh field, source index, timestamp, topology
   declaration, and sequence metadata.
-- Add preflight reporting for unsupported/lossy fields.
+- Add atomic writes and preflight reporting for unsupported metadata.
 
 ### Slice 3: manifested directories
 

--- a/docs/sequence-design.md
+++ b/docs/sequence-design.md
@@ -89,9 +89,9 @@ steps disagree — one clipping an out-of-range color where another raises — a
 the shared model stops being shared.
 
 Positions are stored `float32` and *computed* in `float64` by metric code. That
-halves the footprint of a decoded sequence, which matters because the viewers
-decode every frame they intend to show up front, and it is what a GL buffer wants
-regardless. The cost is roughly 0.5 m of resolution at UTM magnitudes, so
+halves the footprint of decoded frames, which matters because the viewer keeps
+a bounded playback cache, and it is what a GL buffer wants regardless. The cost
+is roughly 0.5 m of resolution at UTM magnitudes, so
 positions are scene-local: a georeferenced capture carries its offset in a
 transform, not in the vertex buffer.
 

--- a/examples/visualization/README.md
+++ b/examples/visualization/README.md
@@ -108,7 +108,6 @@ one and say so.
 | Source | Needs |
 | --- | --- |
 | Folder of `.obj` or `.ply` frames | nothing |
-| Folder of `.usd` frames | `.[usd]` |
 | Folder of `.stl` `.off` `.glb` `.gltf` frames | `.[tools]` |
 | One USD file (`.usd` `.usda` `.usdc` `.usdz`) | `.[usd]` |
 | One mesh file | as above |

--- a/examples/visualization/README.md
+++ b/examples/visualization/README.md
@@ -7,7 +7,7 @@ Two programs on one loader:
 | `visualize_sequence.py` | Play one 4D sequence |
 | `compare_sequences.py` | Put a decoded sequence beside its reference and colour it by error |
 
-Both read a folder of per-frame meshes or a single time-sampled USD file, and
+Both read a single sequence file or an imported folder of per-frame meshes, and
 either one run with no arguments lists every format it accepts.
 
 ## Quick start
@@ -141,23 +141,24 @@ slightly by default: the ramp is monotone in lightness, so brightness already
 carries the magnitude and at full shading a dark patch is ambiguous between deep
 shadow and large error. That is also why the comparison background is dark.
 
-Every frame you display is decoded and measured up front, so reach for
-`--stride N` above a few hundred frames.
+Single-sequence playback decodes on demand with a bounded cache. Comparison
+still measures both complete sequences up front, so reach for `--stride N`
+above a few hundred frames there.
 
 ## In your own code
 
 ```python
-from open4d.io import open_sequence
-from open4d.visualization import visualize
+import open4d
 
-with open_sequence("frames/") as sequence:
+with open4d.load("capture.usdc") as sequence:
     print(len(sequence), sequence.duration, sequence.fps)
-    visualize(sequence, up="y")
+    open4d.visualize(sequence)
+
+open4d.visualize("capture.o4d")
 ```
 
-Loading is lazy — frames decode on access. Measuring needs no viewer. To add a
-format, add one entry to `FRAME_READERS` or `SEQUENCE_OPENERS` in
-`frame_sources.py`.
+Loading and playback are lazy — frames decode on access. Frame directories and
+single mesh files remain supported as ingestion paths. Measuring needs no viewer.
 
 ## The OpenUSD container
 
@@ -173,9 +174,9 @@ frames.
 | --- | --- |
 | `visualize_sequence.py` | The single-sequence program |
 | `compare_sequences.py` | The comparison program |
-| `frame_sources.py` | Format registry and `open_sequence()` |
+| `frame_sources.py` | Thin CLI inspection helpers over `open4d.io` |
 | `open4d.io._mesh` | `.obj` and `.ply`, trimesh fallback |
-| `formats_usd.py` | USD container read and write |
+| `formats_usd.py` | Compatibility wrappers over the public USD backend |
 | `open4d.visualization` | Public viewer, renderer-neutral frames, rotation, shading |
 | `mesh_metrics.py` | Nearest-neighbour search, point-to-point/plane, RMS and PSNR |
 | `compare_frames.py` | Frame pairing, per-frame error, error colours |

--- a/examples/visualization/compare_sequences.py
+++ b/examples/visualization/compare_sequences.py
@@ -6,8 +6,8 @@
         --metric plane --csv error.csv --save compare.gif
 
 This is the comparison viewer; `visualize_sequence.py` is the plain one. Both
-read the same sources — a folder of per-frame meshes or a time-sampled USD
-container — through the same loader, so anything one can open the other can too.
+read the same sources — `.o4d` codec artifacts, time-sampled USD files, frame
+directories, or standalone mesh imports — through the same loader.
 
 Two synchronized panes: the reference as geometry, the decoded mesh coloured by
 its distance to that reference. One camera drives both, because comparing two

--- a/examples/visualization/formats_usd.py
+++ b/examples/visualization/formats_usd.py
@@ -1,333 +1,44 @@
-"""OpenUSD as Open4D's sequence container, plus USD frame reading.
-
-USD is time-sampled by design, so one file holds a whole 4D sequence: the frames
-are time samples on a `points` attribute. That makes it a container rather than
-just a mesh format, and `.usdc` — USD's binary crate format — stores those
-samples compressed.
-
-Needs the usd extra, which provides the `pxr` bindings:
-
-    python -m pip install -e '.[usd]'
-
-## What the container holds
-
-Stage metadata:
-
-- `timeCodesPerSecond` / `framesPerSecond` — the frame rate
-- `startTimeCode` / `endTimeCode` — the frame range
-- up axis
-
-`customLayerData["open4d"]` — the sequence-level record:
-
-- `version`, `generator`, `created`
-- `source`, `source_format` — where the frames came from
-- `frame_count`, `fps`, `duration_seconds`
-- `key_frame_indices` — frames that do not share the previous frame's
-  connectivity, so each one starts a new run of constant topology. Frame 0 is
-  always a key frame.
-
-Geometry streams on `/Open4D/Sequence`, one sample per frame:
-
-- `points` — vertex positions
-- `faceVertexCounts` / `faceVertexIndices` — connectivity, written once when it
-  never changes and time-sampled when it does
-- `extent` — per-frame bounds
-- `primvars:displayColor` — per-vertex colors, when the source has them
-
-Per-frame streams, as custom time-sampled attributes on the same prim:
-
-- `open4d:frameIndex`, `open4d:timestamp`, `open4d:keyFrame`
-- `open4d:vertexCount`, `open4d:triangleCount`
-
-A mesh sequence is written as a `UsdGeom.Mesh`; a point-cloud sequence (frames
-with no faces) as a `UsdGeom.Points`. Both are read back the same way.
-"""
+"""Compatibility wrappers around Open4D's public OpenUSD sequence backend."""
 
 from __future__ import annotations
 
-import datetime as _datetime
-import math
-from numbers import Real
-import sys
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Iterable
 
-import numpy as np
+from open4d import Frame, MemoryFrameProvider, Sequence
+from open4d.io import _usd
 
-# Import first: this puts the repository on sys.path for uninstalled clones.
-import _common  # noqa: F401
-
-from open4d import Frame, Sequence, TopologyMode, TriangleMesh
-
-SUFFIXES = (".usd", ".usda", ".usdc", ".usdz")
-
+SUFFIXES = _usd.USD_SUFFIXES
 CONTAINER_VERSION = 1
-PRIM_PATH = "/Open4D/Sequence"
-
-# Custom per-frame streams: attribute suffix -> USD type name attribute.
-_STREAM_TYPES = {
-    "frameIndex": "Int",
-    "timestamp": "Double",
-    "keyFrame": "Bool",
-    "vertexCount": "Int",
-    "triangleCount": "Int",
-}
-
-_NO_TRIANGLES = np.empty((0, 3), dtype=np.uint32)
-
-
-def _positive_fps(value: float) -> float:
-    if not isinstance(value, Real) or isinstance(value, bool):
-        raise TypeError("fps must be a real number")
-    result = float(value)
-    if not math.isfinite(result) or result <= 0:
-        raise ValueError("fps must be finite and greater than zero")
-    return result
-
-
-def _pxr() -> tuple[Any, Any, Any, Any]:
-    """Import the USD bindings, or exit with the pip command that supplies them."""
-    try:
-        from pxr import Sdf, Usd, UsdGeom, Vt
-    except ImportError:
-        sys.exit(
-            "OpenUSD support needs the 'pxr' bindings, which are not installed.\n"
-            "Install them with: python -m pip install -e '.[usd]'"
-        )
-    return Sdf, Usd, UsdGeom, Vt
-
-
-# ----------------------------
-# Reading
-# ----------------------------
-def _open_stage(path: Path, Usd: Any) -> Any:
-    stage = Usd.Stage.Open(str(path))
-    if stage is None:
-        raise ValueError(f"USD could not open {path}")
-    return stage
-
-
-def _geometry_prim(stage: Any, UsdGeom: Any) -> Any:
-    """Return the container prim, or the first geometry prim on the stage.
-
-    Containers written here live at a known path. Anything else — a DCC export,
-    a scene with cameras and lights and several meshes — falls back to the first
-    mesh or point-based prim, and the reader reports which one it picked.
-    """
-    prim = stage.GetPrimAtPath(PRIM_PATH)
-    if prim and prim.IsValid():
-        return prim
-    for candidate in stage.Traverse():
-        if candidate.IsA(UsdGeom.Mesh) or candidate.IsA(UsdGeom.Points):
-            return candidate
-    raise ValueError("no UsdGeom.Mesh or UsdGeom.Points prim found on the stage")
-
-
-def _triangulate(counts: np.ndarray, indices: np.ndarray) -> np.ndarray:
-    """Fan-triangulate USD's faceVertexCounts/faceVertexIndices pair."""
-    if len(counts) == 0:
-        return _NO_TRIANGLES
-    if np.all(counts == 3):
-        return indices.reshape(-1, 3).astype(np.uint32)
-
-    triangles: list[tuple[int, int, int]] = []
-    offset = 0
-    for count in counts.tolist():
-        face = indices[offset : offset + count]
-        for corner in range(1, count - 1):
-            triangles.append((face[0], face[corner], face[corner + 1]))
-        offset += count
-    return np.array(triangles, dtype=np.uint32).reshape(-1, 3)
-
-
-def _read_colors(prim: Any, vertex_count: int, time: Any, UsdGeom: Any):
-    """Return per-vertex colors from `displayColor`, if there is one per vertex."""
-    primvar = UsdGeom.PrimvarsAPI(prim).GetPrimvar("displayColor")
-    if not primvar:
-        return None
-    value = primvar.Get(time)
-    if value is None:
-        return None
-    colors = np.asarray(value, dtype=np.float32)
-    # USD also allows a single constant color; only per-vertex arrays map onto
-    # TriangleMesh.colors.
-    if colors.ndim != 2 or len(colors) != vertex_count:
-        return None
-    return np.clip(colors, 0.0, 1.0)
-
-
-class UsdSequenceProvider:
-    """Lazy `FrameProvider` over the time samples of one USD geometry prim."""
-
-    def __init__(self, path: Path | str, fps: float | None = None) -> None:
-        self.path = Path(path)
-        self._Sdf, self._Usd, self._UsdGeom, _Vt = _pxr()
-        self._stage = _open_stage(self.path, self._Usd)
-        self._prim = _geometry_prim(self._stage, self._UsdGeom)
-
-        self._points_attr = self._UsdGeom.PointBased(self._prim).GetPointsAttr()
-        if not self._points_attr:
-            raise ValueError(f"{self.path} geometry prim has no points attribute")
-
-        mesh = (
-            self._UsdGeom.Mesh(self._prim)
-            if self._prim.IsA(self._UsdGeom.Mesh)
-            else None
-        )
-        self._counts_attr = mesh.GetFaceVertexCountsAttr() if mesh else None
-        self._indices_attr = mesh.GetFaceVertexIndicesAttr() if mesh else None
-
-        # The time samples on `points` are the frames. A prim with no samples is
-        # a static mesh, which is a one-frame sequence.
-        samples = list(self._points_attr.GetTimeSamples())
-        self._times: list[float | None] = samples or [None]
-
-        # Per-frame streams are optional: a DCC-exported USD will not have them.
-        self._streams = {
-            name: self._prim.GetAttribute(f"open4d:{name}")
-            for name in _STREAM_TYPES
-        }
-        self._streams = {
-            name: attribute
-            for name, attribute in self._streams.items()
-            if attribute and attribute.GetNumTimeSamples() > 0
-        }
-
-        stage_fps = self._stage.GetTimeCodesPerSecond() or 24.0
-        self.fps = _positive_fps(stage_fps if fps is None else fps)
-
-        container = dict(
-            (self._stage.GetRootLayer().customLayerData or {}).get("open4d", {})
-        )
-        if "key_frame_indices" in container:
-            container["key_frame_indices"] = [
-                int(value) for value in container["key_frame_indices"]
-            ]
-        self.metadata = {
-            "name": self.path.stem,
-            "source": str(self.path),
-            "format": self.path.suffix.lower(),
-            "fps": self.fps,
-            "prim": str(self._prim.GetPath()),
-            "prim_type": str(self._prim.GetTypeName()),
-            "up_axis": str(self._UsdGeom.GetStageUpAxis(self._stage)).lower(),
-            "time_samples": len(samples),
-            "per_frame_streams": sorted(self._streams),
-            **container,
-        }
-
-        # Connectivity that is not time-sampled is fixed for the whole sequence,
-        # which is exactly what TopologyMode.FIXED means.
-        if self._counts_attr is None:
-            self.topology = TopologyMode.CHANGING  # point cloud
-        elif self._indices_attr and self._indices_attr.GetNumTimeSamples() > 0:
-            self.topology = TopologyMode.CHANGING
-        else:
-            self.topology = TopologyMode.FIXED
-        self.has_constant_vertex_count = None
-        self.has_vertex_correspondence = None
-
-    @property
-    def frame_count(self) -> int:
-        return len(self._times)
-
-    def _time_code(self, time: float | None) -> Any:
-        return (
-            self._Usd.TimeCode.Default()
-            if time is None
-            else self._Usd.TimeCode(time)
-        )
-
-    @property
-    def timestamps(self) -> tuple[float, ...]:
-        stream = self._streams.get("timestamp")
-        if stream is not None:
-            return tuple(
-                float(stream.Get(self._time_code(time))) for time in self._times
-            )
-        # No stored stream: USD time codes are in frames, so divide by the rate.
-        return tuple(
-            index / self.fps if time is None else float(time) / self.fps
-            for index, time in enumerate(self._times)
-        )
-
-    def get_frame(self, index: int) -> Frame:
-        if index < 0 or index >= self.frame_count:
-            raise IndexError("frame index out of range")
-        time = self._time_code(self._times[index])
-
-        positions = np.asarray(self._points_attr.Get(time), dtype=np.float32)
-        if positions.ndim != 2 or positions.shape[1] != 3:
-            raise ValueError(
-                f"{self.path} frame {index} points have shape {positions.shape}"
-            )
-
-        triangles = _NO_TRIANGLES
-        if self._counts_attr is not None and self._indices_attr is not None:
-            counts = self._counts_attr.Get(time)
-            indices = self._indices_attr.Get(time)
-            if counts is not None and indices is not None:
-                triangles = _triangulate(
-                    np.asarray(counts, dtype=np.int64),
-                    np.asarray(indices, dtype=np.int64),
-                )
-
-        metadata: dict[str, Any] = {"time_code": self._times[index]}
-        for name, attribute in self._streams.items():
-            metadata[name] = attribute.Get(time)
-
-        return Frame(
-            frame_index=index,
-            timestamp=self.timestamps[index],
-            geometry=TriangleMesh(
-                positions=positions,
-                triangles=triangles,
-                colors=_read_colors(
-                    self._prim, len(positions), time, self._UsdGeom
-                ),
-            ),
-            metadata=metadata,
-        )
+PRIM_PATH = _usd.PRIM_PATH
+UsdSequenceProvider = _usd.UsdSequenceProvider
 
 
 def open_usd_sequence(path: Path, fps: float | None = None) -> Sequence:
-    """Open a time-sampled USD file as a core `Sequence`.
-
-    `fps` overrides the stage's own `timeCodesPerSecond`.
-    """
-    return Sequence(UsdSequenceProvider(path, fps=fps))
+    """Open one time-sampled USD file through the public backend."""
+    return _usd.open_usd_sequence(path, fps=fps)
 
 
-def read_usd_frame(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
-    """Read a single frame from a USD file, for folders of per-frame USD.
-
-    Takes the first time sample, or the default value for a static prim.
-    """
-    mesh = UsdSequenceProvider(path).get_frame(0).geometry
-    return mesh.positions, mesh.triangles, mesh.colors
+def read_usd_frame(path: Path):
+    """Read the first frame of a USD sequence for legacy example callers."""
+    with open_usd_sequence(path) as sequence:
+        mesh = sequence[0].geometry
+        return mesh.positions, mesh.triangles, mesh.colors
 
 
-def read_container_metadata(path: Path) -> dict[str, Any]:
-    """Read `customLayerData["open4d"]` without composing a stage.
-
-    Opening the layer alone skips stage composition, and avoids holding a layer
-    whose owning stage has already been collected.
-    """
-    Sdf, _Usd, _UsdGeom, _Vt = _pxr()
-    layer = Sdf.Layer.FindOrOpen(str(path))
-    if layer is None:
-        raise ValueError(f"USD could not open {path}")
-    record = dict((layer.customLayerData or {}).get("open4d", {}))
-    if "key_frame_indices" in record:
-        record["key_frame_indices"] = [
-            int(value) for value in record["key_frame_indices"]
-        ]
-    return record
+def read_container_metadata(path: Path) -> dict:
+    """Return sequence declarations without decoding geometry."""
+    provider = UsdSequenceProvider(path)
+    try:
+        return {
+            **provider._manifest,
+            "frame_count": provider.frame_count,
+            "fps": provider.metadata.get("fps"),
+        }
+    finally:
+        provider.close()
 
 
-# ----------------------------
-# Writing
-# ----------------------------
 def write_usd_container(
     path: Path,
     frames: Iterable[Frame],
@@ -337,187 +48,22 @@ def write_usd_container(
     source_format: str | None = None,
     generator: str | None = None,
 ) -> Path:
-    """Pack frames into one OpenUSD container.
-
-    Writes the geometry streams, the per-frame streams, and the sequence-level
-    record described in this module's docstring. Use a `.usdc` extension for
-    USD's compressed binary crate format, `.usda` to get readable text, or
-    `.usdz` for a single-file package.
-
-    Connectivity is written once when every frame shares it, and time-sampled
-    only where it changes. The frames where it changes are the key frames.
-    """
-    fps = _positive_fps(fps)
-    if not isinstance(up_axis, str) or up_axis.lower() not in {"y", "z"}:
-        raise ValueError("up_axis must be 'y' or 'z' for an OpenUSD stage")
-    up_axis = up_axis.lower()
-
-    # USD prim schemas and primvars must be chosen before samples are authored.
-    # Reiterable sequences are scanned without retaining their geometry; only a
-    # one-shot iterator needs materialization so it can survive the write pass.
-    iterator = iter(frames)
-    if iterator is frames:
-        frames = tuple(iterator)
-
-    frame_count = 0
-    has_triangles = False
-    has_colors = False
-    for index, frame in enumerate(frames):
-        frame_count = index + 1
-        has_triangles = has_triangles or len(frame.geometry.triangles) > 0
-        has_colors = has_colors or frame.geometry.colors is not None
-        if len(frame.geometry.positions) == 0:
-            raise ValueError(
-                f"frame {index} contains no positions; "
-                "USD containers require non-empty geometry"
-            )
-    if frame_count == 0:
-        raise ValueError("cannot write a container with no frames")
-
-    Sdf, Usd, UsdGeom, Vt = _pxr()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists():
-        path.unlink()
-
-    if path.suffix.lower() == ".usdz":
-        # A .usdz is a zip package, and Stage.CreateNew refuses to author one.
-        # Write the crate layer first, then let UsdUtils package it.
-        import tempfile
-
-        from pxr import UsdUtils
-
-        with tempfile.TemporaryDirectory() as scratch:
-            inner = Path(scratch) / f"{path.stem}.usdc"
-            write_usd_container(
-                inner,
-                frames,
-                fps=fps,
-                up_axis=up_axis,
-                source=source,
-                source_format=source_format,
-                generator=generator,
-            )
-            if not UsdUtils.CreateNewUsdzPackage(str(inner), str(path)):
-                raise OSError(f"USD could not package {path}")
-        return path
-
-    stage = Usd.Stage.CreateNew(str(path))
-    UsdGeom.SetStageUpAxis(
-        stage, UsdGeom.Tokens.z if up_axis == "z" else UsdGeom.Tokens.y
-    )
-    stage.SetTimeCodesPerSecond(fps)
-    stage.SetFramesPerSecond(fps)
-
-    if has_triangles:
-        schema = UsdGeom.Mesh.Define(stage, PRIM_PATH)
-        counts_attr = schema.CreateFaceVertexCountsAttr()
-        indices_attr = schema.CreateFaceVertexIndicesAttr()
+    """Write frames through the public OpenUSD sequence writer."""
+    if isinstance(frames, Sequence):
+        sequence = frames
     else:
-        schema = UsdGeom.Points.Define(stage, PRIM_PATH)
-        counts_attr = indices_attr = None
-    geometry_prim = schema.GetPrim()
-    points_attr = schema.CreatePointsAttr()
-    extent_attr = schema.CreateExtentAttr()
-    color_primvar = None
-    if has_colors:
-        color_primvar = UsdGeom.PrimvarsAPI(geometry_prim).CreatePrimvar(
-            "displayColor",
-            Sdf.ValueTypeNames.Color3fArray,
-            UsdGeom.Tokens.vertex,
-        )
-    streams: dict[str, Any] = {}
-    for name, type_name in _STREAM_TYPES.items():
-        streams[name] = geometry_prim.CreateAttribute(
-            f"open4d:{name}",
-            getattr(Sdf.ValueTypeNames, type_name),
-            custom=True,
-        )
-
-    previous_triangles: np.ndarray | None = None
-    first_triangles: np.ndarray | None = None
-    key_frames: list[int] = []
-    timestamps: list[float] = []
-    count = 0
-
-    for index, frame in enumerate(frames):
-        mesh = frame.geometry
-        positions = np.asarray(mesh.positions, dtype=np.float32)
-        triangles = np.asarray(mesh.triangles, dtype=np.int32)
-        time = Usd.TimeCode(index)
-
-        points_attr.Set(Vt.Vec3fArray.FromNumpy(positions), time)
-        extent_attr.Set(
-            Vt.Vec3fArray.FromNumpy(
-                np.stack([positions.min(axis=0), positions.max(axis=0)])
-            ),
-            time,
-        )
-
-        if color_primvar is not None:
-            if mesh.colors is None:
-                colors = np.empty((0, 3), dtype=np.float32)
-            else:
-                colors = np.asarray(mesh.colors)
-                if np.issubdtype(colors.dtype, np.integer):
-                    colors = colors / 255.0
-                colors = np.ascontiguousarray(colors[:, :3], dtype=np.float32)
-            color_primvar.Set(Vt.Vec3fArray.FromNumpy(colors), time)
-
-        is_key_frame = previous_triangles is None or not np.array_equal(
-            previous_triangles, triangles
-        )
-        if counts_attr is not None and is_key_frame:
-            # Every key frame gets a time sample, frame 0 included. Writing
-            # frame 0 as an unvarying default instead would be wrong: once an
-            # attribute has any time samples, USD resolves a query before the
-            # first sample to that sample, so frame 0 would read frame 1's
-            # connectivity. Sequences that never change topology are collapsed
-            # back to a single unvarying value after the loop.
-            counts_attr.Set(Vt.IntArray([3] * len(triangles)), time)
-            indices_attr.Set(Vt.IntArray(triangles.ravel().tolist()), time)
-            if previous_triangles is None:
-                first_triangles = triangles
-
-        timestamp = float(frame.timestamp)
-        streams["frameIndex"].Set(int(frame.frame_index), time)
-        streams["timestamp"].Set(timestamp, time)
-        streams["keyFrame"].Set(bool(is_key_frame), time)
-        streams["vertexCount"].Set(int(len(positions)), time)
-        streams["triangleCount"].Set(int(len(triangles)), time)
-
-        if is_key_frame:
-            key_frames.append(index)
-        previous_triangles = triangles
-        timestamps.append(timestamp)
-        count = index + 1
-
-    # Only frame 0 is a key frame, so connectivity never changed: replace the
-    # single time sample with an unvarying value, which USD stores far more
-    # compactly and which reads as TopologyMode.FIXED.
-    if counts_attr is not None and len(key_frames) == 1:
-        counts_attr.Clear()
-        indices_attr.Clear()
-        counts_attr.Set(Vt.IntArray([3] * len(first_triangles)))
-        indices_attr.Set(Vt.IntArray(first_triangles.ravel().tolist()))
-
-    stage.SetStartTimeCode(0.0)
-    stage.SetEndTimeCode(float(count - 1))
-
-    layer = stage.GetRootLayer()
-    layer.customLayerData = {
-        "open4d": {
-            "version": CONTAINER_VERSION,
-            "generator": generator or "examples/formats_usd.py",
-            "created": _datetime.datetime.now(
-                _datetime.timezone.utc
-            ).isoformat(timespec="seconds"),
-            "source": source or "",
-            "source_format": source_format or "",
-            "frame_count": int(count),
-            "fps": float(fps),
-            "duration_seconds": float(timestamps[-1] - timestamps[0]),
-            "key_frame_indices": Vt.IntArray(key_frames),
-        }
-    }
-    layer.Save()
-    return path
+        sequence = Sequence(MemoryFrameProvider(
+            tuple(frames),
+            metadata={
+                "source": source or "",
+                "source_format": source_format or "",
+                "generator": generator or "examples/visualization/formats_usd.py",
+            },
+        ))
+    return _usd.write_usd_sequence(
+        sequence,
+        path,
+        overwrite=True,
+        fps=fps,
+        up_axis=up_axis,
+    )

--- a/examples/visualization/frame_sources.py
+++ b/examples/visualization/frame_sources.py
@@ -1,321 +1,82 @@
-"""Open a 4D sequence from whatever format it happens to be in.
-
-    sequence = open_sequence("my_capture/")              # folder of .obj/.ply
-    sequence = open_sequence("my_capture.usdc")          # time-sampled USD
-    sequence = open_sequence("frame.obj")                # single static frame
-
-Two shapes of source, dispatched on the suffix:
-
-- **A folder of per-frame files** — one mesh file per frame, ordered by the last
-  number in the filename. Read lazily: only the listing happens up front.
-  Formats come from `FRAME_READERS`.
-- **A single file holding the whole sequence** — a time-sampled USD file.
-  Formats come from `SEQUENCE_OPENERS`.
-
-USD appears in both: a `.usd` file can be an animated sequence on its own, or
-one frame among many in a folder.
-
-Adding a format means adding one entry to a registry. A frame reader takes a
-path and returns `(positions, triangles, colors)`; a sequence opener takes a
-path and an fps and returns a `Sequence`.
-
-One convention worth knowing: `open4d.core` has no point-cloud geometry type
-yet, so a frame with no faces becomes a `TriangleMesh` with zero triangles.
-`len(mesh.triangles) == 0` is the test for "these are just points".
-"""
+"""Thin example helpers around Open4D's public sequence I/O API."""
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
-from typing import Callable
 
-import numpy as np
+from open4d import load as _open_sequence
+from open4d.codec import available_codecs
+from open4d.io import available_formats, inspect_sequence
 
-# Import first: this puts the repository on sys.path for uninstalled clones.
-import _common  # noqa: F401
-
-import formats_usd
-from open4d import Frame, Sequence, TopologyMode, TriangleMesh
-from open4d.io import _mesh as formats_mesh
-
-FrameReader = Callable[[Path], "tuple[np.ndarray, np.ndarray, np.ndarray | None]"]
-SequenceOpener = Callable[..., Sequence]
-
-# Formats that hold ONE frame per file, usable inside a frame folder.
-FRAME_READERS: dict[str, FrameReader] = {
-    ".obj": formats_mesh.read_obj,
-    ".ply": formats_mesh.read_ply,
-    **{suffix: formats_usd.read_usd_frame for suffix in formats_usd.SUFFIXES},
-    **{
-        suffix: formats_mesh.read_with_trimesh
-        for suffix in formats_mesh.TRIMESH_SUFFIXES
-    },
+DEFAULT_FPS = 30.0
+_USD_SUFFIXES = {".usd", ".usda", ".usdc", ".usdz"}
+_CODEC_SUFFIXES = {
+    suffix for info in available_codecs() for suffix in info.suffixes
 }
-
-# Formats where a single file holds the WHOLE sequence.
-SEQUENCE_OPENERS: dict[str, SequenceOpener] = {
-    suffix: formats_usd.open_usd_sequence for suffix in formats_usd.SUFFIXES
-}
-
-# Which extra provides each format, for error messages and `--help` text.
-FORMAT_EXTRAS = {
-    ".obj": None,
-    ".ply": None,
-    ".usd": "usd",
-    ".usda": "usd",
-    ".usdc": "usd",
-    ".usdz": "usd",
-    ".off": "tools",
-    ".stl": "tools",
-    ".glb": "tools",
-    ".gltf": "tools",
-}
-
-FRAME_SUFFIXES = tuple(sorted(FRAME_READERS))
-SEQUENCE_SUFFIXES = tuple(sorted(SEQUENCE_OPENERS))
 
 
 def supported_formats() -> str:
-    """A human-readable summary of every format the loader accepts."""
-    def row(suffix: str) -> str:
-        extra = FORMAT_EXTRAS.get(suffix)
-        return f"  {suffix:<7}{f'  needs the [{extra}] extra' if extra else ''}".rstrip()
-
-    lines = ["per-frame files (a folder of these, or one on its own):"]
-    lines += [row(suffix) for suffix in FRAME_SUFFIXES]
-    lines.append("whole-sequence files:")
-    lines += [row(suffix) for suffix in SEQUENCE_SUFFIXES]
-    return "\n".join(lines)
-
-
-def frame_sort_key(name: str) -> tuple[float, str]:
-    """Order `frame_2` before `frame_10`.
-
-    Sorts on the last integer in the filename, falling back to the name.
-    """
-    numbers = re.findall(r"\d+", name)
-    return (int(numbers[-1]) if numbers else float("inf"), name)
-
-
-def read_frame_file(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
-    """Read one frame, dispatching on the file suffix."""
-    suffix = path.suffix.lower()
-    reader = FRAME_READERS.get(suffix)
-    if reader is None:
-        raise SystemExit(
-            f"No reader for {suffix!r} ({path}).\n{supported_formats()}"
+    """Return concise CLI help for every public input format."""
+    frame_lines = ["per-frame files and import directories:"]
+    sequence_lines = ["whole-sequence files:"]
+    for info in available_formats():
+        extra = (
+            f"  needs the [{info.dependency_extra}] extra"
+            if info.dependency_extra
+            else ""
         )
-    if suffix == ".ply":
-        try:
-            return reader(path)
-        except ValueError:
-            # Exotic PLY variants (big-endian, unusual list elements) are worth
-            # a second try through trimesh rather than a hard failure.
-            return formats_mesh.read_with_trimesh(path)
-    return reader(path)
+        target = sequence_lines if info.id == "usd" else frame_lines
+        target.append(f"  {'/'.join(info.suffixes):<24}{extra}".rstrip())
+    sequence_lines.append("  codec artifacts such as .o4d, .d4d, and .v4d")
+    return "\n".join((*sequence_lines, *frame_lines))
 
 
-def read_geometry(path: Path) -> TriangleMesh:
-    """Read one frame file into a validated `TriangleMesh`.
-
-    Parse and validation failures are re-raised naming the file. Pointed at a
-    real dataset, one malformed frame among hundreds is the common case, and
-    "positions must have shape (N, 3)" on its own does not say which file.
-    """
-    try:
-        positions, triangles, colors = read_frame_file(path)
-        return TriangleMesh(
-            positions=positions, triangles=triangles, colors=colors
-        )
-    except SystemExit:
-        raise  # a missing-dependency exit, already actionable
-    except Exception as error:
-        # Deliberately not `type(error)(...)`: plenty of exceptions take more
-        # than one constructor argument — UnicodeDecodeError takes five — and
-        # rebuilding them swallows the real error behind a TypeError.
-        raise ValueError(
-            f"{path}: {type(error).__name__}: {error}"
-        ) from error
-
-
-def list_frame_files(directory: Path) -> list[Path]:
-    """Return the per-frame files in *directory*, in frame order.
-
-    When a folder mixes formats, the most common suffix wins; the rest are
-    reported and skipped rather than silently interleaved.
-    """
-    files = [
-        entry
-        for entry in directory.iterdir()
-        if entry.is_file() and entry.suffix.lower() in FRAME_READERS
-    ]
-    if not files:
-        raise SystemExit(
-            f"{directory} contains no frame files.\n{supported_formats()}"
-        )
-
-    by_suffix: dict[str, list[Path]] = {}
-    for entry in files:
-        by_suffix.setdefault(entry.suffix.lower(), []).append(entry)
-    if len(by_suffix) > 1:
-        chosen = max(by_suffix, key=lambda suffix: len(by_suffix[suffix]))
-        skipped = sorted(set(by_suffix) - {chosen})
-        print(
-            f"note: {directory} mixes formats; reading {len(by_suffix[chosen])} "
-            f"{chosen} frames and skipping {', '.join(skipped)}"
-        )
-        files = by_suffix[chosen]
-
-    files.sort(key=lambda entry: frame_sort_key(entry.name))
-    return files
-
-
-class FolderFrameProvider:
-    """Lazy `FrameProvider` over a folder holding one mesh file per frame.
-
-    Only the directory listing is done eagerly; each file is parsed when
-    `get_frame()` is called, so a long sequence never has to fit in memory.
-    """
-
-    # Independently-reconstructed frames carry no promise that connectivity or
-    # vertex count is stable, so leave that undeclared rather than claim
-    # something the files do not support.
-    topology = TopologyMode.UNKNOWN
-    has_constant_vertex_count = None
-    has_vertex_correspondence = None
-
-    def __init__(self, directory: Path | str, fps: float = 30.0) -> None:
-        if fps <= 0:
-            raise ValueError("fps must be greater than zero")
-        self.directory = Path(directory)
-        self.fps = float(fps)
-        self.files = list_frame_files(self.directory)
-        self.metadata = {
-            "name": self.directory.name,
-            "source": str(self.directory),
-            "fps": self.fps,
-            "num_source_files": len(self.files),
-            "format": sorted({entry.suffix.lower() for entry in self.files}),
-        }
-
-    @property
-    def frame_count(self) -> int:
-        return len(self.files)
-
-    @property
-    def timestamps(self) -> tuple[float, ...]:
-        return tuple(index / self.fps for index in range(len(self.files)))
-
-    def get_frame(self, index: int) -> Frame:
-        if index < 0 or index >= self.frame_count:
-            raise IndexError("frame index out of range")
-        path = self.files[index]
-        return Frame(
-            frame_index=index,
-            timestamp=index / self.fps,
-            geometry=read_geometry(path),
-            metadata={"file": path.name},
-        )
-
-
-class SingleFrameProvider:
-    """A one-frame `Sequence` from a single static mesh file."""
-
-    topology = TopologyMode.FIXED
-    has_constant_vertex_count = True
-    has_vertex_correspondence = True
-
-    def __init__(self, path: Path | str) -> None:
-        self.path = Path(path)
-        self.metadata = {
-            "name": self.path.stem,
-            "source": str(self.path),
-            "format": self.path.suffix.lower(),
-            "frames": 1,
-        }
-
-    frame_count = 1
-    timestamps = (0.0,)
-
-    def get_frame(self, index: int) -> Frame:
-        if index != 0:
-            raise IndexError("frame index out of range")
-        return Frame(
-            frame_index=0,
-            timestamp=0.0,
-            geometry=read_geometry(self.path),
-            metadata={"file": self.path.name},
-        )
-
-
-# ----------------------------
-# The one entry point
-# ----------------------------
 def source_kind(path: Path | str) -> str:
-    """Classify a source without decoding it.
-
-    Returns ``"folder"``, ``"sequence-file"``, or ``"single-frame"``.
-    """
+    """Classify a source without decoding its geometry."""
     path = Path(path)
     if path.is_dir():
         return "folder"
     if not path.exists():
         raise SystemExit(f"{path} does not exist")
-    suffix = path.suffix.lower()
-    if suffix in SEQUENCE_OPENERS:
+    if path.suffix.lower() in _USD_SUFFIXES | _CODEC_SUFFIXES:
         return "sequence-file"
-    if suffix in FRAME_READERS:
-        return "single-frame"
-    raise SystemExit(
-        f"{path} has no reader for {suffix!r}.\n{supported_formats()}"
-    )
+    try:
+        inspect_sequence(path)
+    except Exception as error:
+        raise SystemExit(str(error)) from None
+    return "single-frame"
 
 
-DEFAULT_FPS = 30.0
-
-
-def open_sequence(path: Path | str, fps: float | None = None) -> Sequence:
-    """Open a frame folder, a whole-sequence file, or a single mesh file.
-
-    `fps` is an override. Leave it None and each source uses whatever timing it
-    declares: a USD file its own stage rate, a frame folder `DEFAULT_FPS` since
-    a folder declares nothing. Passing a number forces that rate everywhere —
-    which is why it must default to None rather than to a real value, or the
-    default would silently override every stage rate it met.
-    """
+def open_sequence(path: Path | str, fps: float | None = None):
+    """Load a source, using ``fps`` only to timestamp frame directories."""
     path = Path(path)
-    kind = source_kind(path)
-
-    if kind == "folder":
-        folder_fps = DEFAULT_FPS if fps is None else fps
-        return Sequence(FolderFrameProvider(path, fps=folder_fps))
-    if kind == "sequence-file":
-        return SEQUENCE_OPENERS[path.suffix.lower()](path, fps)
-    return Sequence(SingleFrameProvider(path))
+    return _open_sequence(path, fps=fps if path.is_dir() else None)
 
 
 def describe_source(path: Path | str) -> str:
-    """One line about a source, without parsing any geometry."""
+    """Describe a source through public inspection without geometry decoding."""
     path = Path(path)
-    kind = source_kind(path)
-
-    if kind == "folder":
-        files = list_frame_files(path)
-        formats = ", ".join(sorted({entry.suffix.lower() for entry in files}))
-        megabytes = sum(entry.stat().st_size for entry in files) / 1e6
-        return f"folder: {len(files)} {formats} frames, {megabytes:.2f} MB on disk"
-
-    megabytes = path.stat().st_size / 1e6
-    if kind == "single-frame":
-        return f"single {path.suffix.lower()} frame, {megabytes:.2f} MB on disk"
-
-    suffix = path.suffix.lower()
-    detail = suffix
-    if suffix in formats_usd.SUFFIXES:
-        # The container records its own frame count, so report it without
-        # composing a stage or touching the geometry.
-        record = formats_usd.read_container_metadata(path)
-        if record.get("frame_count"):
-            detail = f"{suffix} ({record['frame_count']} frames)"
-    return f"sequence file: {detail}, {megabytes:.2f} MB on disk"
+    if path.suffix.lower() in _CODEC_SUFFIXES and path.is_file():
+        with _open_sequence(path) as sequence:
+            return (
+                f"sequence file: {path.suffix.lower()} ({len(sequence)} frames), "
+                f"{path.stat().st_size / 1e6:.2f} MB on disk"
+            )
+    info = inspect_sequence(path)
+    if path.is_dir():
+        megabytes = sum(
+            entry.stat().st_size for entry in path.iterdir() if entry.is_file()
+        ) / 1e6
+    else:
+        megabytes = path.stat().st_size / 1e6
+    if info.storage == "container":
+        return (
+            f"sequence file: {path.suffix.lower()} ({info.frame_count} frames), "
+            f"{megabytes:.2f} MB on disk"
+        )
+    if info.storage == "directory":
+        return (
+            f"frame directory: {info.frame_count} {info.format} frames, "
+            f"{megabytes:.2f} MB on disk"
+        )
+    return f"single {info.format} import frame, {megabytes:.2f} MB on disk"

--- a/examples/visualization/tests/test_formats_usd.py
+++ b/examples/visualization/tests/test_formats_usd.py
@@ -60,12 +60,12 @@ def test_usd_writer_rejects_x_up_without_mislabelling_geometry(tmp_path):
     assert not destination.exists()
 
 
-def test_usd_writer_rejects_empty_geometry_before_touching_destination(tmp_path):
+def test_usd_writer_round_trips_empty_geometry(tmp_path):
     destination = tmp_path / "frame.usdc"
-    destination.write_text("keep me", encoding="utf-8")
     empty = frame(0, positions=np.empty((0, 3), dtype=np.float32))
 
-    with pytest.raises(ValueError, match="frame 0.*no positions"):
-        formats_usd.write_usd_container(destination, [empty])
+    formats_usd.write_usd_container(destination, [empty])
+    decoded = formats_usd.open_usd_sequence(destination)
 
-    assert destination.read_text(encoding="utf-8") == "keep me"
+    assert decoded[0].geometry.positions.shape == (0, 3)
+    decoded.close()

--- a/examples/visualization/tests/test_frame_sources.py
+++ b/examples/visualization/tests/test_frame_sources.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 import frame_sources
@@ -33,3 +35,11 @@ def test_example_helpers_treat_codec_artifacts_as_whole_sequences(tmp_path):
     # timestamp override for a self-describing sequence artifact.
     with frame_sources.open_sequence(artifact, fps=12) as sequence:
         assert len(sequence) == 1
+
+
+def test_documentation_does_not_advertise_usd_frame_directories():
+    readme = Path(frame_sources.__file__).with_name("README.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Folder of `.usd` frames" not in readme

--- a/examples/visualization/tests/test_frame_sources.py
+++ b/examples/visualization/tests/test_frame_sources.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 
 import frame_sources
+import open4d
+from open4d import Frame, MemoryFrameProvider, Sequence, TriangleMesh
 
 pytestmark = pytest.mark.cpu
 
@@ -14,3 +16,20 @@ def test_folder_loader_rejects_an_explicit_zero_fps(tmp_path):
 
     with pytest.raises(ValueError, match="fps"):
         frame_sources.open_sequence(tmp_path, fps=0)
+
+
+def test_example_helpers_treat_codec_artifacts_as_whole_sequences(tmp_path):
+    mesh = TriangleMesh(
+        [[0.0, 0, 0], [1, 0, 0], [0, 1, 0]], [[0, 1, 2]]
+    )
+    artifact = open4d.save(
+        Sequence(MemoryFrameProvider([Frame(0, 0.0, mesh)])),
+        tmp_path / "capture.o4d",
+    )
+
+    assert frame_sources.source_kind(artifact) == "sequence-file"
+    assert "1 frames" in frame_sources.describe_source(artifact)
+    # This is a playback override in the example CLIs, not an import-time
+    # timestamp override for a self-describing sequence artifact.
+    with frame_sources.open_sequence(artifact, fps=12) as sequence:
+        assert len(sequence) == 1

--- a/examples/visualization/tests/test_visualize_sequence.py
+++ b/examples/visualization/tests/test_visualize_sequence.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+import pytest
+
+import visualize_sequence as cli
+from open4d import Frame, Sequence, TriangleMesh
+from open4d.visualization._frames import LazyRenderSequence
+
+pytestmark = pytest.mark.cpu
+
+
+def test_malformed_codec_source_is_reported_without_a_traceback(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "broken.o4d"
+    path.write_bytes(b"not an Open4D artifact")
+    monkeypatch.setattr(sys, "argv", ["visualize_sequence.py", str(path), "--info"])
+
+    with pytest.raises(SystemExit) as caught:
+        cli.main()
+
+    message = str(caught.value)
+    assert "failed to read the sequence" in message
+    assert "Traceback" not in message
+
+
+def test_malformed_usd_source_is_reported_without_a_traceback(
+    tmp_path, monkeypatch
+):
+    pytest.importorskip("pxr")
+    path = tmp_path / "broken.usda"
+    path.write_text("not valid USD", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["visualize_sequence.py", str(path), "--info"])
+
+    with pytest.raises(SystemExit) as caught:
+        cli.main()
+
+    message = str(caught.value)
+    assert "failed to read the sequence" in message
+    assert "Traceback" not in message
+
+
+def test_single_sequence_cli_reaches_playback_without_eager_decoding(
+    tmp_path, monkeypatch
+):
+    calls = []
+
+    class Provider:
+        frame_count = 20
+        timestamps = tuple(index / 30 for index in range(frame_count))
+        metadata = {"fps": 30.0}
+
+        def get_frame(self, index):
+            calls.append(index)
+            positions = np.array(
+                [[index, 0, 0], [index + 1, 0, 0], [index, 1, 0]],
+                dtype=np.float32,
+            )
+            return Frame(index, index / 30, TriangleMesh(positions, [[0, 1, 2]]))
+
+    sequence = Sequence(Provider())
+    path = tmp_path / "capture.o4d"
+    path.touch()
+    captured = {}
+    monkeypatch.setattr(cli, "open_sequence", lambda *args, **kwargs: sequence)
+    monkeypatch.setattr(cli, "describe_source", lambda path: "test sequence")
+    monkeypatch.setattr(sys, "argv", ["visualize_sequence.py", str(path)])
+    from open4d.visualization import _qt
+
+    def play(frames, args):
+        captured["frames"] = frames
+        captured["closed_during_playback"] = sequence.closed
+        captured["calls_at_playback"] = list(calls)
+
+    monkeypatch.setattr(_qt, "play", play)
+
+    cli.main()
+
+    assert isinstance(captured["frames"], LazyRenderSequence)
+    assert captured["closed_during_playback"] is False
+    assert captured["calls_at_playback"] == [0]
+    assert calls == [0]
+    assert sequence.closed is True

--- a/examples/visualization/visualize_sequence.py
+++ b/examples/visualization/visualize_sequence.py
@@ -5,14 +5,14 @@
     python examples/visualization/visualize_sequence.py my_capture/ --up y --save out.gif
     python examples/visualization/visualize_sequence.py my_capture.usdc
 
-Point it at your own data. A source is either a folder holding one mesh file per
-frame (`.obj`, `.ply`, `.usd`, or anything trimesh reads) or a single
-time-sampled USD file. Meshes and point clouds are both handled: a frame with no
-faces is drawn as a point cloud.
+Point it at your own data. A source is normally a whole-sequence file such as
+`.o4d` or a time-sampled `.usdc`. A folder holding one mesh per frame and a
+standalone mesh remain useful import paths. Meshes and point clouds are both
+handled: a frame with no faces is drawn as a point cloud.
 
-Start with `--info`. It reports frame count, duration, topology and bounds
-without decoding geometry or opening a window, which is the quickest way to see
-whether a dataset loads and what the loader made of it.
+Start with `--info`. It reports frame count, timing, and topology without
+decoding geometry or opening a window, which is the quickest way to see whether
+a dataset loads and what the loader made of it.
 
 In the window: drag to orbit, scroll to zoom, drag the slider to scrub, space to
 pause, left/right to step, q to quit. Frame number, timestamp and vertex/triangle
@@ -37,10 +37,17 @@ from _common import existing_source
 from frame_sources import (
     DEFAULT_FPS,
     describe_source,
-    open_sequence,
     supported_formats,
 )
-from open4d.visualization._frames import UP_AXES, UP_TO_Z, bounds, decode_all
+from open4d import load as open_sequence, save as save_sequence
+from open4d.codec import CodecError
+from open4d.io import Open4DError
+from open4d.visualization._frames import (
+    LazyRenderSequence,
+    UP_AXES,
+    UP_TO_Z,
+    bounds,
+)
 
 # pyqtgraph draws with +Z up, so the source's up axis is rotated onto Z and the
 # axis pointing up in the view is index 2.
@@ -89,37 +96,15 @@ def resolve_up(sequence, requested: str | None) -> str:
     return recorded if recorded in UP_TO_Z else "z"
 
 
-def report_geometry(frames: list, stride: int) -> None:
-    """Print what the decoded frames turned out to be.
+def report_geometry(frame, frame_count: int, stride: int) -> None:
+    """Describe the first display frame without forcing an eager bounds scan."""
+    lower, upper = bounds([frame])
 
-    Each frame is tested individually: a folder of `.ply` where some frames have
-    faces and some do not yields a mix of meshes and point clouds, and assuming
-    the whole sequence matches frame 0 raises AttributeError on the first
-    mismatch.
-    """
-    kinds = {frame.is_mesh for frame in frames}
-    counts = [len(frame.positions) for frame in frames]
-    faces = [len(frame.triangles) for frame in frames]
-    lower, upper = bounds(frames)
-
-    def summarize(values: list[int]) -> str:
-        unique = sorted(set(values))
-        if len(unique) == 1:
-            return str(unique[0])
-        return f"{unique[0]}..{unique[-1]} ({len(unique)} distinct)"
-
-    if kinds == {True}:
-        description = "triangle mesh"
-    elif kinds == {False}:
-        description = "point cloud"
-    else:
-        description = "mixed: some frames have faces, some do not"
-
-    print(f"\ndecoded {len(frames)} frames (stride {stride})")
-    print(f"  geometry   : {description}")
-    print(f"  vertices   : {summarize(counts)}")
-    if True in kinds:
-        print(f"  triangles  : {summarize(faces)}")
+    print(f"\nfirst decoded frame of {frame_count} (stride {stride})")
+    print(f"  geometry   : {'triangle mesh' if frame.is_mesh else 'point cloud'}")
+    print(f"  vertices   : {len(frame.positions)}")
+    if frame.is_mesh:
+        print(f"  triangles  : {len(frame.triangles)}")
     print(f"  bounds     : {lower.round(2)} .. {upper.round(2)}")
 
     # After reordering the up axis is PLOT_UP. A subject much longer along a
@@ -131,7 +116,7 @@ def report_geometry(frames: list, stride: int) -> None:
     if longest != PLOT_UP:
         runner_up = float(np.partition(extents, -2)[-2])
         if extents[longest] > 1.5 * max(runner_up, 1e-9):
-            print("  note: the sequence is longest across the view, not "
+            print("  note: the first frame is longest across the view, not "
                   "upright — the up axis may be wrong, try --up x/y/z")
 
 
@@ -145,8 +130,8 @@ def main() -> None:
         "path",
         type=Path,
         nargs="?",
-        help="your sequence: a folder of per-frame mesh files, or a USD "
-        "container",
+        help="your sequence: an .o4d or USD file, a frame directory, or a "
+        "standalone mesh import",
     )
     parser.add_argument(
         "--stride", type=int, default=1, help="keep every Nth frame"
@@ -155,8 +140,8 @@ def main() -> None:
         "--fps",
         type=float,
         default=None,
-        help="override the frame rate; by default a USD file's own stage rate "
-        "is used, and a folder gets 30",
+        help="override playback; for a manifest-free frame directory this also "
+        "defines imported timestamps (default: 30 fps)",
     )
     parser.add_argument(
         "--up",
@@ -239,7 +224,8 @@ def main() -> None:
     # A malformed frame in someone else's dataset is ordinary, not a crash, so
     # report it as an error naming the file rather than a traceback.
     try:
-        with open_sequence(path, fps=args.fps) as sequence:
+        import_fps = args.fps if path.is_dir() else None
+        with open_sequence(path, fps=import_fps) as sequence:
             # One rate, resolved once, used for reporting, playback, GIF timing
             # and any container we write.
             fps = resolve_fps(sequence, args.fps)
@@ -249,22 +235,11 @@ def main() -> None:
                 raise SystemExit(f"{path} contains no frames")
 
             if args.pack_usd:
-                from formats_usd import write_usd_container
-
-                # A folder reports its formats as a list, a container as one
-                # string; record either as a plain string.
-                source_format = sequence.metadata.get("format", "")
-                if isinstance(source_format, (list, tuple)):
-                    source_format = ", ".join(source_format)
-
-                written = write_usd_container(
-                    args.pack_usd,
+                written = save_sequence(
                     sequence,
                     fps=fps,
                     up_axis=resolve_up(sequence, args.up),
-                    source=str(path),
-                    source_format=str(source_format),
-                    generator="examples/visualization/visualize_sequence.py",
+                    destination=args.pack_usd,
                 )
                 print(f"\nwrote {written} "
                       f"({written.stat().st_size / 1e6:.2f} MB)")
@@ -273,18 +248,21 @@ def main() -> None:
                 return
 
             up = resolve_up(sequence, args.up)
-            frames = decode_all(sequence, args.stride, UP_TO_Z[up])
-    except (ValueError, TypeError, OSError) as error:
+            frames = LazyRenderSequence(
+                sequence,
+                stride=args.stride,
+                order=UP_TO_Z[up],
+            )
+            report_geometry(frames[0], len(frames), args.stride)
+
+            from open4d.visualization import _qt as viewer_qt
+
+            if args.save:
+                viewer_qt.record(frames, args, args.save)
+            else:
+                viewer_qt.play(frames, args)
+    except (Open4DError, CodecError, ValueError, TypeError, OSError) as error:
         raise SystemExit(f"\nfailed to read the sequence:\n  {error}") from None
-
-    report_geometry(frames, args.stride)
-
-    from open4d.visualization import _qt as viewer_qt
-
-    if args.save:
-        viewer_qt.record(frames, args, args.save)
-    else:
-        viewer_qt.play(frames, args)
 
 
 if __name__ == "__main__":

--- a/open4d/__init__.py
+++ b/open4d/__init__.py
@@ -17,6 +17,8 @@ from .core import (
     TriangleMesh,
     dtypes,
 )
+from ._api import load, save, unload
+from .visualization import visualize
 
 __all__ = [
     "ATTRIBUTE_FLOAT_DTYPE",
@@ -34,4 +36,8 @@ __all__ = [
     "TriangleMesh",
     "UV_DTYPE",
     "dtypes",
+    "load",
+    "save",
+    "unload",
+    "visualize",
 ]

--- a/open4d/_api.py
+++ b/open4d/_api.py
@@ -1,0 +1,130 @@
+"""Unified whole-sequence entry points for Open4D."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import os
+from pathlib import Path
+
+from .codec import Codec, available_codecs, decode_sequence, encode_sequence
+from .core import Sequence
+from .io import open_sequence, write_sequence
+
+_USD_SUFFIXES = frozenset((".usd", ".usda", ".usdc", ".usdz"))
+
+
+def _options(value: Mapping[str, object] | None) -> dict[str, object]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError("options must be a mapping or None")
+    return dict(value)
+
+
+def _codec_suffixes() -> dict[str, list[str]]:
+    suffixes: dict[str, list[str]] = {}
+    for info in available_codecs():
+        for suffix in info.suffixes:
+            suffixes.setdefault(suffix.lower(), []).append(info.id)
+    return suffixes
+
+
+def load(
+    source: str | os.PathLike[str],
+    *,
+    format: str | None = None,
+    codec: str | Codec | None = None,
+    fps: float | None = None,
+    options: Mapping[str, object] | None = None,
+) -> Sequence:
+    """Open a complete sequence artifact or an importable geometry source."""
+    if format is not None and codec is not None:
+        raise TypeError("format and codec are mutually exclusive")
+    values = _options(options)
+    path = Path(source)
+    if codec is not None:
+        if fps is not None:
+            raise TypeError("fps applies to I/O sources, not codec artifacts")
+        return decode_sequence(path, codec=codec, **values)
+    if not path.is_dir() and path.suffix.lower() in _codec_suffixes():
+        if format is not None:
+            raise TypeError("format cannot select a codec artifact")
+        if fps is not None:
+            raise TypeError("fps applies to I/O sources, not codec artifacts")
+        return decode_sequence(path, **values)
+    return open_sequence(path, format=format, fps=fps, options=values)
+
+
+def save(
+    sequence: Sequence,
+    destination: str | os.PathLike[str],
+    *,
+    codec: str | Codec | None = None,
+    overwrite: bool = False,
+    fps: float | None = None,
+    up_axis: str | None = None,
+    options: Mapping[str, object] | None = None,
+) -> Path:
+    """Write a sequence to one OpenUSD or codec artifact file."""
+    if not isinstance(sequence, Sequence):
+        raise TypeError("sequence must be an open4d.Sequence")
+    if not isinstance(overwrite, bool):
+        raise TypeError("overwrite must be bool")
+    path = Path(destination)
+    suffix = path.suffix.lower()
+    values = _options(options)
+    if "overwrite" in values:
+        raise TypeError("overwrite must be passed as the named argument")
+
+    if suffix in _USD_SUFFIXES:
+        if codec is not None:
+            raise TypeError("codec cannot be used with an OpenUSD destination")
+        values.update(
+            item
+            for item in (("fps", fps), ("up_axis", up_axis))
+            if item[1] is not None
+        )
+        return write_sequence(
+            sequence, path, overwrite=overwrite, options=values
+        )
+
+    suffixes = _codec_suffixes()
+    if codec is None:
+        matches = suffixes.get(suffix, [])
+        if suffix == ".o4d":
+            codec = "npz"
+        elif len(matches) == 1:
+            codec = matches[0]
+        elif len(matches) > 1:
+            raise ValueError(
+                f"ambiguous sequence-file extension {suffix!r}; pass codec="
+            )
+        else:
+            raise ValueError(
+                f"destination needs a recognized sequence-file extension; got "
+                f"{suffix or 'no extension'}"
+            )
+    implementation_suffixes = (
+        tuple(codec.suffixes)
+        if not isinstance(codec, str)
+        else next(
+            (info.suffixes for info in available_codecs() if info.id == codec),
+            (),
+        )
+    )
+    if implementation_suffixes and suffix not in implementation_suffixes:
+        raise ValueError(
+            f"destination extension {suffix!r} does not match codec {codec!r}"
+        )
+    if fps is not None or up_axis is not None:
+        raise TypeError("fps and up_axis apply only to OpenUSD destinations")
+    return encode_sequence(
+        sequence, path, codec=codec, overwrite=overwrite, **values
+    )
+
+
+def unload(sequence: Sequence) -> None:
+    """Release resources owned by a loaded sequence."""
+    if not isinstance(sequence, Sequence):
+        raise TypeError("sequence must be an open4d.Sequence")
+    sequence.close()

--- a/open4d/core/sequence.py
+++ b/open4d/core/sequence.py
@@ -47,6 +47,15 @@ class Sequence:
         return self._frame_count
 
     @property
+    def closed(self) -> bool:
+        """Whether this sequence has released its provider resources."""
+        return self._closed
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("sequence is closed")
+
+    @property
     def frame_count(self) -> int:
         return len(self)
 
@@ -70,6 +79,7 @@ class Sequence:
             TypeError: If `index` is not an integer or slice, or if the provider returns an invalid frame.
             IndexError: If an integer index is outside the sequence bounds.
         """
+        self._ensure_open()
         if isinstance(index, slice):
             return SequenceView(self, range(len(self))[index])
         if isinstance(index, bool):
@@ -92,6 +102,7 @@ class Sequence:
         return self[index]
 
     def __iter__(self) -> Iterator[Frame]:
+        self._ensure_open()
         for index in range(len(self)):
             yield self[index]
 
@@ -111,6 +122,7 @@ class Sequence:
         	TypeError: If timestamps or the provider's monotonicity setting have an invalid type.
         	ValueError: If timestamps have an invalid length, contain non-finite values, or decrease when nonmonotonic timestamps are disallowed.
         """
+        self._ensure_open()
         if self._timestamps_cache is None:
             provided = getattr(self._provider, "timestamps", None)
             values = provided if provided is not None else (
@@ -212,6 +224,7 @@ class Sequence:
 
     def __enter__(self) -> "Sequence":
         """Enter the sequence's context-manager scope and return the sequence."""
+        self._ensure_open()
         return self
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:

--- a/open4d/core/tests/test_temporal.py
+++ b/open4d/core/tests/test_temporal.py
@@ -369,3 +369,19 @@ def test_closing_a_view_does_not_close_its_parent():
     assert provider.closed is False
     parent.close()
     assert provider.closed is True
+
+
+def test_closed_sequence_rejects_frame_and_timing_access_but_keeps_declarations():
+    sequence = Sequence(MemoryFrameProvider(
+        frames(), metadata={"capture": "test"}, topology=TopologyMode.FIXED
+    ))
+    sequence.close()
+
+    assert sequence.closed is True
+    assert len(sequence) == 4
+    assert sequence.metadata == {"capture": "test"}
+    assert sequence.topology is TopologyMode.FIXED
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = sequence[0]
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = sequence.timestamps

--- a/open4d/io/_api.py
+++ b/open4d/io/_api.py
@@ -1,4 +1,4 @@
-"""Public sequence loading over heterogeneous per-frame mesh storage."""
+"""Public sequence loading over containers and per-frame mesh storage."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ import numpy as np
 
 from open4d.core import Frame, Sequence, TopologyMode, TriangleMesh
 
-from . import _mesh
+from . import _mesh, _usd
 from ._errors import (
     AmbiguousFormatError,
     DecodeError,
@@ -59,7 +59,7 @@ _OUTPUT_FIELDS = {
 
 @dataclass(frozen=True)
 class FormatInfo:
-    """A per-frame format understood by the installed Open4D package."""
+    """A storage format understood by the installed Open4D package."""
 
     id: str
     suffixes: tuple[str, ...]
@@ -83,10 +83,13 @@ class SequenceInfo:
 
 
 def available_formats() -> tuple[FormatInfo, ...]:
-    """Return the per-frame formats supported by the public loader."""
-    return tuple(
+    """Return the geometry and sequence formats supported by the public loader."""
+    mesh_formats = tuple(
         FormatInfo(identifier, (suffix,), _FORMAT_DEPENDENCIES[suffix])
         for identifier, suffix in sorted(_FORMAT_IDS.items())
+    )
+    return mesh_formats + (
+        FormatInfo("usd", _usd.USD_SUFFIXES, "usd"),
     )
 
 
@@ -94,13 +97,36 @@ def _supported_formats() -> str:
     """Return supported formats as concise CLI help text."""
     lines = ["per-frame mesh files (one file or a directory of frames):"]
     for info in available_formats():
+        if info.id == "usd":
+            continue
         extra = (
             f"  needs the [{info.dependency_extra}] extra"
             if info.dependency_extra
             else ""
         )
         lines.append(f"  {info.suffixes[0]:<7}{extra}".rstrip())
+    lines.append("sequence containers:")
+    lines.append("  .usd/.usda/.usdc/.usdz  needs the [usd] extra")
     return "\n".join(lines)
+
+
+def _is_usd_request(path: Path, format: str | None) -> bool:
+    if path.suffix.lower() in _usd.USD_SUFFIXES and not path.is_dir():
+        if format is None:
+            return True
+        if not isinstance(format, str) or not format.strip():
+            raise TypeError("format must be a non-empty string or None")
+        requested = format.strip().lower().lstrip(".")
+        if requested not in {"usd", path.suffix.lower().lstrip(".")}:
+            raise UnsupportedFormatError(
+                f"requested format {format!r} does not match {path.suffix!r}"
+            )
+        return True
+    if isinstance(format, str) and format.strip().lower().lstrip(".") in {
+        "usd", "usda", "usdc", "usdz"
+    }:
+        return True
+    return False
 
 
 def _suffix_for(format: str | None) -> str | None:
@@ -390,6 +416,21 @@ def inspect_sequence(
     source: str | os.PathLike[str], *, format: str | None = None
 ) -> SequenceInfo:
     """Inspect a local mesh file or frame directory without decoding geometry."""
+    candidate = Path(source).absolute()
+    if not candidate.exists():
+        raise SourceNotFoundError(f"Sequence source does not exist: {candidate}")
+    if _is_usd_request(candidate, format):
+        details = _usd.inspect_usd_sequence(candidate)
+        return SequenceInfo(
+            source=candidate,
+            storage="container",
+            format="usd",
+            frame_count=details["frame_count"],
+            geometry_kind="triangle_mesh",
+            fps=details["fps"],
+            timing_source="container",
+            topology=details["topology"],
+        )
     path, storage, files, suffix, manifest = _resolve(source, format)
     is_directory = storage == "directory"
     timestamps = tuple(record["timestamp"] for record in manifest["frames"]) if manifest else ()
@@ -421,11 +462,18 @@ def open_sequence(
     if options is not None:
         if not isinstance(options, Mapping):
             raise TypeError("options must be a mapping or None")
-        if options:
-            names = ", ".join(sorted(str(name) for name in options))
-            raise UnsupportedFeatureError(
-                f"This reader has no options; received: {names}"
-            )
+    candidate = Path(source).absolute()
+    if not candidate.exists():
+        raise SourceNotFoundError(f"Sequence source does not exist: {candidate}")
+    if _is_usd_request(candidate, format):
+        return _usd.open_usd_sequence(
+            candidate, fps=fps, options=options
+        )
+    if options:
+        names = ", ".join(sorted(str(name) for name in options))
+        raise UnsupportedFeatureError(
+            f"This reader has no options; received: {names}"
+        )
     path, storage, files, suffix, manifest = _resolve(source, format)
     if storage == "directory":
         if manifest is not None:
@@ -485,13 +533,44 @@ def write_sequence(
     format: str | None = None,
     overwrite: bool = False,
     allow_lossy: bool = False,
+    options: Mapping[str, object] | None = None,
 ) -> Path:
-    """Write a sequence, requiring ``allow_lossy`` for single mesh files."""
+    """Write a sequence container or explicitly export per-frame mesh files."""
     if not isinstance(sequence, Sequence):
         raise TypeError("sequence must be an open4d.Sequence")
     if not isinstance(allow_lossy, bool):
         raise TypeError("allow_lossy must be bool")
     destination = Path(destination).absolute()
+    if options is not None and not isinstance(options, Mapping):
+        raise TypeError("options must be a mapping or None")
+    values = dict(options or {})
+    usd_format = (
+        isinstance(format, str)
+        and format.strip().lower().lstrip(".") in {"usd", "usda", "usdc", "usdz"}
+    )
+    if destination.suffix.lower() in _usd.USD_SUFFIXES or usd_format:
+        if destination.suffix.lower() not in _usd.USD_SUFFIXES:
+            raise UnsupportedFormatError(
+                "OpenUSD sequence output requires a .usd, .usda, .usdc, or .usdz suffix"
+            )
+        requested = format.strip().lower().lstrip(".") if usd_format else None
+        if requested not in {None, "usd", destination.suffix.lower().lstrip(".")}:
+            raise UnsupportedFormatError(
+                f"destination suffix {destination.suffix!r} does not match "
+                f"format {format!r}"
+            )
+        unknown = set(values) - {"fps", "up_axis"}
+        if unknown:
+            raise UnsupportedFeatureError(
+                f"Unknown OpenUSD writer options: {', '.join(sorted(unknown))}"
+            )
+        return _usd.write_usd_sequence(
+            sequence, destination, overwrite=overwrite, **values
+        )
+    if values:
+        raise UnsupportedFeatureError(
+            f"This writer has no options; received: {', '.join(sorted(values))}"
+        )
     suffix = _suffix_for(format)
     file_output = destination.suffix.lower() in _FRAME_READERS
     if suffix is None:

--- a/open4d/io/_usd.py
+++ b/open4d/io/_usd.py
@@ -1,0 +1,682 @@
+"""OpenUSD sequence-container reader and writer."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import math
+from numbers import Real
+import os
+from pathlib import Path
+import tempfile
+from types import MappingProxyType
+from typing import Any
+
+import numpy as np
+
+from open4d.core import Frame, Sequence, TopologyMode, TriangleMesh
+
+from ._errors import (
+    DecodeError,
+    EncodeError,
+    MissingDependencyError,
+    UnsupportedFeatureError,
+)
+
+USD_SUFFIXES = (".usd", ".usda", ".usdc", ".usdz")
+SCHEMA = "open4d.usd-sequence/v1"
+PRIM_PATH = "/Open4D/Sequence"
+_DEFAULT_FPS = 30.0
+_NO_TRIANGLES = np.empty((0, 3), dtype=np.uint32)
+
+
+def _pxr():
+    try:
+        from pxr import Sdf, Usd, UsdGeom, Vt
+    except ImportError as error:
+        raise MissingDependencyError(
+            "OpenUSD support needs the optional dependency; install it with: "
+            "python -m pip install 'open4d[usd]'"
+        ) from error
+    return Sdf, Usd, UsdGeom, Vt
+
+
+def _json_value(value: Any, name: str) -> Any:
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise EncodeError(f"{name} metadata numbers must be finite")
+        return value
+    if isinstance(value, np.generic):
+        return _json_value(value.item(), name)
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise EncodeError(f"{name} metadata keys must be strings")
+        return {
+            key: _json_value(item, f"{name}.{key}")
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item, name) for item in value]
+    raise EncodeError(
+        f"{name} metadata value {type(value).__name__} is not serializable"
+    )
+
+
+def _positive_fps(value: float | None, sequence: Sequence | None = None) -> float:
+    if value is None:
+        declared = None if sequence is None else sequence.metadata.get("fps")
+        value = declared if declared is not None else (
+            None if sequence is None else sequence.fps
+        )
+        if value is None:
+            value = _DEFAULT_FPS
+    if not isinstance(value, Real) or isinstance(value, bool):
+        raise TypeError("fps must be a real number or None")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0:
+        raise ValueError("fps must be finite and greater than zero")
+    return result
+
+
+def _attribute_kind(array: np.ndarray) -> str:
+    if np.issubdtype(array.dtype, np.floating):
+        return "float"
+    if np.issubdtype(array.dtype, np.integer):
+        return "int"
+    if np.issubdtype(array.dtype, np.bool_):
+        return "bool"
+    raise EncodeError(f"unsupported custom attribute dtype {array.dtype}")
+
+
+def _triangulate(counts: np.ndarray, indices: np.ndarray) -> np.ndarray:
+    if not len(counts):
+        return _NO_TRIANGLES
+    if np.any(counts < 3) or int(counts.sum()) != len(indices):
+        raise DecodeError("USD face counts do not match face indices")
+    if np.all(counts == 3):
+        return np.asarray(indices, dtype=np.uint32).reshape(-1, 3)
+    triangles: list[tuple[int, int, int]] = []
+    offset = 0
+    for count in counts.tolist():
+        face = indices[offset : offset + count]
+        triangles.extend(
+            (int(face[0]), int(face[corner]), int(face[corner + 1]))
+            for corner in range(1, count - 1)
+        )
+        offset += count
+    return np.asarray(triangles, dtype=np.uint32).reshape(-1, 3)
+
+
+def _geometry_prim(stage: Any, UsdGeom: Any, prim_path: str | None) -> Any:
+    if prim_path is not None:
+        prim = stage.GetPrimAtPath(prim_path)
+        if not prim or not prim.IsValid():
+            raise DecodeError(f"USD prim does not exist: {prim_path}")
+        return prim
+    prim = stage.GetPrimAtPath(PRIM_PATH)
+    if prim and prim.IsValid():
+        return prim
+    for candidate in stage.Traverse():
+        if candidate.IsA(UsdGeom.Mesh) or candidate.IsA(UsdGeom.Points):
+            return candidate
+    raise DecodeError("USD stage contains no mesh or point geometry")
+
+
+def _time_samples(attributes: tuple[Any, ...]) -> tuple[float | None, ...]:
+    """Return the ordered union of samples that can change a decoded frame."""
+    samples: set[float] = set()
+    for attribute in attributes:
+        if attribute:
+            samples.update(float(value) for value in attribute.GetTimeSamples())
+    return tuple(sorted(samples)) or (None,)
+
+
+def _read_manifest(stage: Any) -> tuple[dict[str, Any], bool]:
+    record = dict(
+        (stage.GetRootLayer().customLayerData or {}).get("open4d", {})
+    )
+    if record.get("schema") == SCHEMA:
+        try:
+            manifest = json.loads(record["manifest"])
+        except (KeyError, TypeError, json.JSONDecodeError) as error:
+            raise DecodeError(f"invalid Open4D USD manifest: {error}") from error
+        if not isinstance(manifest, dict):
+            raise DecodeError("Open4D USD manifest must be an object")
+        return manifest, True
+    return record, False
+
+
+class UsdSequenceProvider:
+    """Lazy frame provider over one time-sampled USD geometry prim."""
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        *,
+        fps: float | None = None,
+        prim_path: str | None = None,
+    ) -> None:
+        self.path = Path(path).absolute()
+        self._Sdf, self._Usd, self._UsdGeom, self._Vt = _pxr()
+        try:
+            self._stage = self._Usd.Stage.Open(str(self.path))
+        except Exception as error:
+            raise DecodeError(f"USD could not open {self.path}: {error}") from error
+        if self._stage is None:
+            raise DecodeError(f"USD could not open {self.path}")
+        self._prim = _geometry_prim(self._stage, self._UsdGeom, prim_path)
+        self._points = self._UsdGeom.PointBased(self._prim).GetPointsAttr()
+        if not self._points:
+            raise DecodeError(f"USD geometry prim {self._prim.GetPath()} has no points")
+        mesh = self._UsdGeom.Mesh(self._prim) if self._prim.IsA(self._UsdGeom.Mesh) else None
+        self._counts = mesh.GetFaceVertexCountsAttr() if mesh else None
+        self._indices = mesh.GetFaceVertexIndicesAttr() if mesh else None
+        self._extent = self._UsdGeom.Boundable(self._prim).GetExtentAttr()
+        self._colors = self._UsdGeom.PrimvarsAPI(self._prim).GetPrimvar("displayColor")
+        self._opacity = self._UsdGeom.PrimvarsAPI(self._prim).GetPrimvar("displayOpacity")
+        self._normals = mesh.GetNormalsAttr() if mesh else None
+        self._vertex_uv = self._prim.GetAttribute("open4d:vertexUV")
+        self._corner_uv = self._prim.GetAttribute("open4d:cornerUV")
+        self._frame_index = self._prim.GetAttribute("open4d:frameIndex")
+        self._timestamp = self._prim.GetAttribute("open4d:timestamp")
+        self._descriptor = self._prim.GetAttribute("open4d:frameDescriptor")
+        self._legacy_streams = {
+            name: self._prim.GetAttribute(f"open4d:{name}")
+            for name in (
+                "frameIndex",
+                "timestamp",
+                "keyFrame",
+                "vertexCount",
+                "triangleCount",
+            )
+        }
+        self._legacy_streams = {
+            name: attribute
+            for name, attribute in self._legacy_streams.items()
+            if attribute and attribute.GetNumTimeSamples() > 0
+        }
+
+        self._manifest, self._native = _read_manifest(self._stage)
+        custom_streams = tuple(
+            attribute
+            for attribute in self._prim.GetAttributes()
+            if attribute.GetName().startswith("open4d:attribute")
+        )
+        self._times = _time_samples((
+            self._points,
+            self._counts,
+            self._indices,
+            self._colors,
+            self._opacity,
+            self._normals,
+            self._vertex_uv,
+            self._corner_uv,
+            self._frame_index,
+            self._timestamp,
+            self._descriptor,
+            *self._legacy_streams.values(),
+            *custom_streams,
+        ))
+        stage_fps = self._stage.GetTimeCodesPerSecond() or _DEFAULT_FPS
+        self.fps = _positive_fps(stage_fps if fps is None else fps)
+
+        if self._native:
+            try:
+                self.topology = TopologyMode(
+                    self._manifest.get("topology", "unknown")
+                )
+            except ValueError as error:
+                raise DecodeError(f"invalid USD topology declaration: {error}") from error
+            self.has_constant_vertex_count = self._manifest.get(
+                "has_constant_vertex_count"
+            )
+            self.has_vertex_correspondence = self._manifest.get(
+                "has_vertex_correspondence"
+            )
+            self.allow_nonmonotonic_timestamps = self._manifest.get(
+                "allow_nonmonotonic_timestamps", False
+            )
+            sequence_metadata = self._manifest.get("metadata", {})
+        else:
+            self.topology = (
+                TopologyMode.CHANGING
+                if any(
+                    attribute and attribute.GetNumTimeSamples() > 0
+                    for attribute in (self._counts, self._indices)
+                )
+                else TopologyMode.FIXED
+            )
+            self.has_constant_vertex_count = None
+            self.has_vertex_correspondence = None
+            self.allow_nonmonotonic_timestamps = False
+            sequence_metadata = {}
+        if not isinstance(sequence_metadata, Mapping):
+            raise DecodeError("USD sequence metadata must be an object")
+        provider_metadata = {
+            "name": self.path.stem,
+            "source": str(self.path),
+            "format": self.path.suffix.lower(),
+            "fps": float(self._manifest.get("fps", self.fps)),
+            "up_axis": str(self._UsdGeom.GetStageUpAxis(self._stage)).lower(),
+            "prim": str(self._prim.GetPath()),
+            "prim_type": str(self._prim.GetTypeName()),
+            "schema": self._manifest.get("schema", SCHEMA if self._native else None),
+        }
+        # The prototype layout exposed its custom-layer record as provider
+        # metadata. Keep that behavior for old files; v1 instead restores the
+        # sequence metadata stored in its manifest and reserves provider keys.
+        if self._native:
+            metadata = {**dict(sequence_metadata), **provider_metadata}
+        else:
+            metadata = {**provider_metadata, **dict(self._manifest)}
+        self.metadata = MappingProxyType(metadata)
+
+    @property
+    def frame_count(self) -> int:
+        return len(self._times)
+
+    def _time(self, ordinal: int):
+        value = self._times[ordinal]
+        return self._Usd.TimeCode.Default() if value is None else self._Usd.TimeCode(value)
+
+    @property
+    def timestamps(self) -> tuple[float, ...]:
+        if self._timestamp and self._timestamp.GetNumTimeSamples() > 0:
+            return tuple(float(self._timestamp.Get(self._time(i))) for i in range(len(self._times)))
+        return tuple(
+            index / self.fps if value is None else float(value) / self.fps
+            for index, value in enumerate(self._times)
+        )
+
+    def _descriptor_at(self, index: int) -> dict[str, Any]:
+        if not self._descriptor:
+            return {}
+        value = self._descriptor.Get(self._time(index))
+        if not value:
+            return {}
+        try:
+            result = json.loads(value)
+        except (TypeError, json.JSONDecodeError) as error:
+            raise DecodeError(f"invalid USD frame {index} descriptor: {error}") from error
+        if not isinstance(result, dict):
+            raise DecodeError(f"USD frame {index} descriptor must be an object")
+        return result
+
+    def get_frame(self, index: int) -> Frame:
+        if index < 0 or index >= self.frame_count:
+            raise IndexError("frame index out of range")
+        time = self._time(index)
+        try:
+            points_value = self._points.Get(time)
+            positions = np.asarray(points_value or [], dtype=np.float32).reshape(-1, 3)
+            triangles = _NO_TRIANGLES
+            if self._counts and self._indices:
+                counts_value = self._counts.Get(time)
+                indices_value = self._indices.Get(time)
+                if counts_value is not None and indices_value is not None:
+                    triangles = _triangulate(
+                        np.asarray(counts_value, dtype=np.int64),
+                        np.asarray(indices_value, dtype=np.int64),
+                    )
+
+            descriptor = self._descriptor_at(index)
+            colors = None
+            channels = int(descriptor.get("color_channels", 0))
+            if channels and self._colors:
+                rgb = np.asarray(self._colors.Get(time), dtype=np.float32).reshape(-1, 3)
+                if channels == 4:
+                    alpha = np.asarray(self._opacity.Get(time), dtype=np.float32).reshape(-1, 1)
+                    colors = np.column_stack((rgb, alpha))
+                else:
+                    colors = rgb
+            elif not self._native and self._colors:
+                value = self._colors.Get(time)
+                if value is not None:
+                    candidate = np.asarray(value, dtype=np.float32).reshape(-1, 3)
+                    if len(candidate) == len(positions):
+                        colors = candidate
+
+            normals = None
+            if descriptor.get("normals") and self._normals:
+                normals = np.asarray(self._normals.Get(time), dtype=np.float32).reshape(-1, 3)
+
+            texture_coordinates = None
+            uv_layout = descriptor.get("uv_layout")
+            uv_shape = tuple(descriptor.get("uv_shape", ()))
+            if uv_layout == "vertex" and self._vertex_uv:
+                texture_coordinates = np.asarray(
+                    self._vertex_uv.Get(time), dtype=np.float32
+                ).reshape(uv_shape)
+            elif uv_layout == "corner" and self._corner_uv:
+                texture_coordinates = np.asarray(
+                    self._corner_uv.Get(time), dtype=np.float32
+                ).reshape(uv_shape)
+
+            attributes = {}
+            for record in descriptor.get("attributes", ()):
+                stream = self._prim.GetAttribute(record["stream"])
+                if not stream:
+                    raise DecodeError(
+                        f"USD frame {index} is missing custom stream {record['stream']}"
+                    )
+                dtype = {
+                    "float": np.float32,
+                    "int": np.int32,
+                    "bool": np.bool_,
+                }[record["kind"]]
+                attributes[record["name"]] = np.asarray(
+                    stream.Get(time), dtype=dtype
+                ).reshape(tuple(record["shape"]))
+
+            frame_index = (
+                int(self._frame_index.Get(time))
+                if self._frame_index
+                else index
+            )
+            timestamp = (
+                float(self._timestamp.Get(time))
+                if self._timestamp
+                else self.timestamps[index]
+            )
+            metadata = descriptor.get("metadata", {})
+            if not self._native:
+                metadata = {"time_code": self._times[index]}
+                metadata.update({
+                    name: attribute.Get(time)
+                    for name, attribute in self._legacy_streams.items()
+                })
+            return Frame(
+                frame_index,
+                timestamp,
+                TriangleMesh(
+                    positions,
+                    triangles,
+                    colors=colors,
+                    normals=normals,
+                    texture_coordinates=texture_coordinates,
+                    attributes=attributes,
+                ),
+                metadata,
+            )
+        except (DecodeError, IndexError):
+            raise
+        except Exception as error:
+            raise DecodeError(
+                f"Could not decode USD frame {index} from {self.path}: "
+                f"{type(error).__name__}: {error}"
+            ) from error
+
+    def close(self) -> None:
+        self._stage = None
+        self._prim = None
+
+
+def open_usd_sequence(
+    source: str | os.PathLike[str],
+    *,
+    fps: float | None = None,
+    options: Mapping[str, object] | None = None,
+) -> Sequence:
+    values = dict(options or {})
+    unknown = set(values) - {"prim_path"}
+    if unknown:
+        raise UnsupportedFeatureError(
+            f"Unknown OpenUSD reader options: {', '.join(sorted(unknown))}"
+        )
+    return Sequence(UsdSequenceProvider(source, fps=fps, **values))
+
+
+def inspect_usd_sequence(source: str | os.PathLike[str]):
+    provider = UsdSequenceProvider(source)
+    try:
+        return {
+            "frame_count": provider.frame_count,
+            "fps": provider.metadata.get("fps"),
+            "topology": provider.topology,
+        }
+    finally:
+        provider.close()
+
+
+def _preflight(sequence: Sequence) -> tuple[dict[str, Any], list[dict[str, Any]], dict[tuple[str, str], str]]:
+    if not len(sequence):
+        raise UnsupportedFeatureError("empty sequences cannot be exported")
+    manifest = {
+        "schema": SCHEMA,
+        "metadata": _json_value(sequence.metadata, "sequence"),
+        "topology": sequence.topology.value,
+        "has_constant_vertex_count": sequence.has_constant_vertex_count,
+        "has_vertex_correspondence": sequence.has_vertex_correspondence,
+        "allow_nonmonotonic_timestamps": sequence.allow_nonmonotonic_timestamps,
+        "frame_count": len(sequence),
+    }
+    raw_descriptors: list[dict[str, Any]] = []
+    schemas: set[tuple[str, str]] = set()
+    for ordinal, frame in enumerate(sequence):
+        mesh = frame.geometry
+        attributes = []
+        for name, array in mesh.attributes.items():
+            kind = _attribute_kind(array)
+            schemas.add((name, kind))
+            attributes.append({
+                "name": name,
+                "kind": kind,
+                "shape": list(array.shape),
+            })
+        uv = mesh.texture_coordinates
+        raw_descriptors.append({
+            "metadata": _json_value(frame.metadata, f"frame {ordinal}"),
+            "color_channels": 0 if mesh.colors is None else int(mesh.colors.shape[1]),
+            "normals": mesh.normals is not None,
+            "uv_layout": None if uv is None else ("vertex" if uv.ndim == 2 else "corner"),
+            "uv_shape": [] if uv is None else list(uv.shape),
+            "attributes": attributes,
+        })
+    streams = {
+        schema: f"open4d:attribute{index:04d}:{schema[1]}"
+        for index, schema in enumerate(sorted(schemas))
+    }
+    for descriptor in raw_descriptors:
+        for record in descriptor["attributes"]:
+            record["stream"] = streams[(record["name"], record["kind"])]
+    return manifest, raw_descriptors, streams
+
+
+def _author_stage(
+    path: Path,
+    sequence: Sequence,
+    manifest: dict[str, Any],
+    descriptors: list[dict[str, Any]],
+    streams: dict[tuple[str, str], str],
+    *,
+    fps: float,
+    up_axis: str,
+) -> None:
+    Sdf, Usd, UsdGeom, Vt = _pxr()
+    stage = Usd.Stage.CreateNew(str(path))
+    if stage is None:
+        raise EncodeError(f"USD could not create {path}")
+    stage.SetInterpolationType(Usd.InterpolationTypeHeld)
+    stage.SetTimeCodesPerSecond(fps)
+    stage.SetFramesPerSecond(fps)
+    UsdGeom.SetStageUpAxis(
+        stage, UsdGeom.Tokens.y if up_axis == "y" else UsdGeom.Tokens.z
+    )
+    schema = UsdGeom.Mesh.Define(stage, PRIM_PATH)
+    prim = schema.GetPrim()
+    points = schema.CreatePointsAttr()
+    counts = schema.CreateFaceVertexCountsAttr()
+    indices = schema.CreateFaceVertexIndicesAttr()
+    extent = schema.CreateExtentAttr()
+    colors = UsdGeom.PrimvarsAPI(prim).CreatePrimvar(
+        "displayColor", Sdf.ValueTypeNames.Color3fArray, UsdGeom.Tokens.vertex
+    )
+    opacity = UsdGeom.PrimvarsAPI(prim).CreatePrimvar(
+        "displayOpacity", Sdf.ValueTypeNames.FloatArray, UsdGeom.Tokens.vertex
+    )
+    normals = schema.CreateNormalsAttr()
+    schema.SetNormalsInterpolation(UsdGeom.Tokens.vertex)
+    vertex_uv = prim.CreateAttribute("open4d:vertexUV", Sdf.ValueTypeNames.Float2Array)
+    corner_uv = prim.CreateAttribute("open4d:cornerUV", Sdf.ValueTypeNames.Float2Array)
+    frame_index = prim.CreateAttribute("open4d:frameIndex", Sdf.ValueTypeNames.Int)
+    timestamp = prim.CreateAttribute("open4d:timestamp", Sdf.ValueTypeNames.Double)
+    descriptor_attr = prim.CreateAttribute("open4d:frameDescriptor", Sdf.ValueTypeNames.String)
+    custom_attrs = {}
+    for (_name, kind), stream in streams.items():
+        type_name = {
+            "float": Sdf.ValueTypeNames.FloatArray,
+            "int": Sdf.ValueTypeNames.IntArray,
+            "bool": Sdf.ValueTypeNames.BoolArray,
+        }[kind]
+        custom_attrs[stream] = prim.CreateAttribute(stream, type_name)
+
+    previous_triangles = None
+    key_frames = []
+    for ordinal, frame in enumerate(sequence):
+        time = Usd.TimeCode(ordinal)
+        mesh = frame.geometry
+        points.Set(Vt.Vec3fArray.FromNumpy(np.ascontiguousarray(mesh.positions)), time)
+        if len(mesh.positions):
+            extent.Set(
+                Vt.Vec3fArray.FromNumpy(
+                    np.asarray(
+                        [mesh.positions.min(axis=0), mesh.positions.max(axis=0)],
+                        dtype=np.float32,
+                    )
+                ),
+                time,
+            )
+        triangles = np.asarray(mesh.triangles, dtype=np.int32)
+        is_key = previous_triangles is None or not np.array_equal(previous_triangles, triangles)
+        if is_key:
+            counts.Set(Vt.IntArray([3] * len(triangles)), time)
+            indices.Set(Vt.IntArray(triangles.reshape(-1).tolist()), time)
+            key_frames.append(ordinal)
+        previous_triangles = triangles.copy()
+
+        descriptor = descriptors[ordinal]
+        if mesh.colors is not None:
+            colors.Set(
+                Vt.Vec3fArray.FromNumpy(
+                    np.ascontiguousarray(mesh.colors[:, :3], dtype=np.float32)
+                ),
+                time,
+            )
+            if mesh.colors.shape[1] == 4:
+                opacity.Set(
+                    Vt.FloatArray.FromNumpy(
+                        np.ascontiguousarray(mesh.colors[:, 3], dtype=np.float32)
+                    ),
+                    time,
+                )
+            else:
+                opacity.Set(Vt.FloatArray(), time)
+        else:
+            colors.Set(Vt.Vec3fArray(), time)
+            opacity.Set(Vt.FloatArray(), time)
+        if mesh.normals is not None:
+            normals.Set(
+                Vt.Vec3fArray.FromNumpy(np.ascontiguousarray(mesh.normals)), time
+            )
+        else:
+            normals.Set(Vt.Vec3fArray(), time)
+        uv = mesh.texture_coordinates
+        if uv is not None:
+            target = vertex_uv if uv.ndim == 2 else corner_uv
+            target.Set(
+                Vt.Vec2fArray.FromNumpy(
+                    np.ascontiguousarray(uv.reshape(-1, 2), dtype=np.float32)
+                ),
+                time,
+            )
+        for record in descriptor["attributes"]:
+            value = mesh.attributes[record["name"]].reshape(-1)
+            array_type = {
+                "float": Vt.FloatArray,
+                "int": Vt.IntArray,
+                "bool": Vt.BoolArray,
+            }[record["kind"]]
+            custom_attrs[record["stream"]].Set(
+                array_type.FromNumpy(np.ascontiguousarray(value)), time
+            )
+        frame_index.Set(int(frame.frame_index), time)
+        timestamp.Set(float(frame.timestamp), time)
+        descriptor_attr.Set(
+            json.dumps(descriptor, separators=(",", ":"), sort_keys=True), time
+        )
+
+    stage.SetStartTimeCode(0)
+    stage.SetEndTimeCode(len(sequence) - 1)
+    manifest.update({
+        "fps": fps,
+        "up_axis": up_axis,
+        "key_frame_indices": key_frames,
+    })
+    stage.GetRootLayer().customLayerData = {
+        "open4d": {
+            "schema": SCHEMA,
+            "manifest": json.dumps(manifest, separators=(",", ":"), sort_keys=True),
+        }
+    }
+    if not stage.GetRootLayer().Save():
+        raise EncodeError(f"USD could not save {path}")
+
+
+def write_usd_sequence(
+    sequence: Sequence,
+    destination: str | os.PathLike[str],
+    *,
+    overwrite: bool = False,
+    fps: float | None = None,
+    up_axis: str | None = None,
+) -> Path:
+    if not isinstance(sequence, Sequence):
+        raise TypeError("sequence must be an open4d.Sequence")
+    destination = Path(destination).absolute()
+    if destination.suffix.lower() not in USD_SUFFIXES:
+        raise ValueError("OpenUSD destination must end in .usd, .usda, .usdc, or .usdz")
+    if destination.exists() and not overwrite:
+        raise FileExistsError(f"destination already exists: {destination}")
+    selected_up = up_axis or str(sequence.metadata.get("up_axis", "z")).lower()
+    if selected_up not in {"y", "z"}:
+        raise ValueError("up_axis must be 'y' or 'z'")
+    selected_fps = _positive_fps(fps, sequence)
+    manifest, descriptors, streams = _preflight(sequence)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    handle, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.stem}.", suffix=destination.suffix,
+        dir=destination.parent,
+    )
+    os.close(handle)
+    temporary = Path(temporary_name)
+    temporary.unlink()
+    try:
+        if destination.suffix.lower() == ".usdz":
+            _Sdf, _Usd, _UsdGeom, _Vt = _pxr()
+            from pxr import UsdUtils
+            with tempfile.TemporaryDirectory() as directory:
+                inner = Path(directory) / f"{destination.stem}.usdc"
+                _author_stage(
+                    inner, sequence, manifest, descriptors, streams,
+                    fps=selected_fps, up_axis=selected_up,
+                )
+                if not UsdUtils.CreateNewUsdzPackage(str(inner), str(temporary)):
+                    raise EncodeError(f"USD could not package {destination}")
+        else:
+            _author_stage(
+                temporary, sequence, manifest, descriptors, streams,
+                fps=selected_fps, up_axis=selected_up,
+            )
+        temporary.replace(destination)
+        return destination
+    except Exception as error:
+        temporary.unlink(missing_ok=True)
+        if isinstance(error, (EncodeError, UnsupportedFeatureError, MissingDependencyError, TypeError, ValueError)):
+            raise
+        raise EncodeError(
+            f"Could not encode {destination}: {type(error).__name__}: {error}"
+        ) from error

--- a/open4d/io/_usd.py
+++ b/open4d/io/_usd.py
@@ -550,6 +550,8 @@ def _author_stage(
                 ),
                 time,
             )
+        else:
+            extent.Set(Vt.Vec3fArray(), time)
         triangles = np.asarray(mesh.triangles, dtype=np.int32)
         is_key = previous_triangles is None or not np.array_equal(previous_triangles, triangles)
         if is_key:

--- a/open4d/io/tests/test_unified_api.py
+++ b/open4d/io/tests/test_unified_api.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import open4d
+from open4d import Frame, MemoryFrameProvider, Sequence, TriangleMesh
+
+pytestmark = pytest.mark.cpu
+
+
+def sequence() -> Sequence:
+    mesh = TriangleMesh(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        [[0, 1, 2]],
+    )
+    return Sequence(MemoryFrameProvider([Frame(7, 1.25, mesh)]))
+
+
+def test_top_level_codec_round_trip_and_unload(tmp_path):
+    artifact = open4d.save(sequence(), tmp_path / "capture.o4d")
+
+    loaded = open4d.load(artifact)
+    np.testing.assert_array_equal(loaded[0].geometry.triangles, [[0, 1, 2]])
+    assert loaded.closed is False
+
+    assert open4d.unload(loaded) is None
+    assert loaded.closed is True
+    open4d.unload(loaded)
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = loaded[0]
+    with pytest.raises(RuntimeError, match="closed"):
+        _ = loaded.timestamps
+
+
+def test_top_level_load_keeps_mesh_files_as_import_sources(tmp_path):
+    path = tmp_path / "frame.obj"
+    path.write_text(
+        "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="ascii"
+    )
+
+    loaded = open4d.load(path)
+
+    assert len(loaded) == 1
+    np.testing.assert_array_equal(loaded[0].geometry.triangles, [[0, 1, 2]])
+
+
+def test_top_level_load_rejects_conflicting_dispatch_overrides(tmp_path):
+    path = tmp_path / "frame.obj"
+    path.write_text(
+        "v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="ascii"
+    )
+
+    with pytest.raises(TypeError, match="format.*codec"):
+        open4d.load(path, format="obj", codec="npz")
+
+
+@pytest.mark.parametrize("name", ("capture", "frame.obj", "capture.unknown"))
+def test_top_level_save_requires_a_sequence_file_extension(tmp_path, name):
+    with pytest.raises(ValueError, match="sequence-file extension"):
+        open4d.save(sequence(), tmp_path / name)
+
+
+def test_top_level_save_requires_a_codec_for_ambiguous_codec_suffix(tmp_path):
+    with pytest.raises(ValueError, match=r"ambiguous.*\.v4d.*codec"):
+        open4d.save(sequence(), tmp_path / "capture.v4d")
+
+
+def test_top_level_api_exports_visualize():
+    assert callable(open4d.visualize)

--- a/open4d/io/tests/test_usd_sequence.py
+++ b/open4d/io/tests/test_usd_sequence.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pxr")
+
+import open4d
+from open4d import Frame, MemoryFrameProvider, Sequence, TopologyMode, TriangleMesh
+from open4d.io import (
+    EncodeError,
+    MissingDependencyError,
+    available_formats,
+    inspect_sequence,
+    open_sequence,
+    write_sequence,
+)
+
+pytestmark = pytest.mark.cpu
+
+
+def rich_sequence() -> Sequence:
+    first = TriangleMesh(
+        positions=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+        triangles=[[0, 1, 2]],
+        colors=[[1, 0, 0, 0.25], [0, 1, 0, 0.5], [0, 0, 1, 0.75]],
+        normals=np.array([[0, 0, 1]] * 3, dtype=np.float32),
+        texture_coordinates=np.array([[0, 0], [1, 0], [0, 1]], dtype=np.float32),
+        attributes={
+            "weights": np.arange(6, dtype=np.float32).reshape(3, 2),
+            "labels": np.array([4, 5, 6], dtype=np.int32),
+            "selected": np.array([True], dtype=np.bool_),
+        },
+    )
+    second = TriangleMesh(
+        positions=np.array(
+            [[0, 0, 0], [2, 0, 0], [0, 2, 0], [0, 0, 2]], dtype=np.float32
+        ),
+        triangles=[[0, 1, 2], [0, 2, 3]],
+        normals=np.array([[0, 0, 1]] * 4, dtype=np.float32),
+        texture_coordinates=np.array(
+            [[[0, 0], [1, 0], [0, 1]], [[0, 0], [0, 1], [1, 1]]],
+            dtype=np.float32,
+        ),
+        attributes={
+            "weights": np.arange(8, dtype=np.float32).reshape(4, 2),
+            "labels": np.array([7, 8, 9, 10], dtype=np.int32),
+            "visible": np.array([True, False, True, False], dtype=np.bool_),
+        },
+    )
+    return Sequence(MemoryFrameProvider(
+        [
+            Frame(41, 5.0, first, {"camera": "left", "quality": 0.5}),
+            Frame(43, 4.0, second, {"camera": "right", "tags": ["a", "b"]}),
+        ],
+        metadata={"capture": "rafa", "nested": {"take": 2}},
+        topology=TopologyMode.CHANGING,
+        has_constant_vertex_count=False,
+        has_vertex_correspondence=False,
+        allow_nonmonotonic_timestamps=True,
+    ))
+
+
+def assert_rich_round_trip(expected: Sequence, actual: Sequence) -> None:
+    assert actual.metadata["capture"] == "rafa"
+    assert actual.metadata["nested"] == {"take": 2}
+    assert actual.topology is TopologyMode.CHANGING
+    assert actual.has_constant_vertex_count is False
+    assert actual.has_vertex_correspondence is False
+    assert actual.allow_nonmonotonic_timestamps is True
+    assert actual.timestamps == (5.0, 4.0)
+    for left, right in zip(expected, actual, strict=True):
+        assert right.frame_index == left.frame_index
+        assert right.timestamp == left.timestamp
+        assert right.metadata == left.metadata
+        for name in (
+            "positions", "triangles", "colors", "normals", "texture_coordinates"
+        ):
+            expected_value = getattr(left.geometry, name)
+            actual_value = getattr(right.geometry, name)
+            if expected_value is None:
+                assert actual_value is None
+            else:
+                np.testing.assert_array_equal(actual_value, expected_value)
+        assert set(right.geometry.attributes) == set(left.geometry.attributes)
+        for name, value in left.geometry.attributes.items():
+            np.testing.assert_array_equal(right.geometry.attributes[name], value)
+
+
+@pytest.mark.parametrize("suffix", (".usda", ".usdc", ".usdz"))
+def test_public_usd_round_trip_preserves_the_complete_model(tmp_path, suffix):
+    source = rich_sequence()
+    destination = tmp_path / f"capture{suffix}"
+
+    output = open4d.save(source, destination, fps=30, up_axis="y")
+    info = inspect_sequence(output)
+    decoded = open4d.load(output)
+
+    assert output == destination.absolute()
+    assert output.is_file()
+    assert info.storage == "container"
+    assert info.format == "usd"
+    assert info.frame_count == 2
+    assert info.timing_source == "container"
+    assert decoded.metadata["up_axis"] == "y"
+    assert_rich_round_trip(source, decoded)
+    decoded.close()
+
+
+def test_public_usd_load_is_lazy(tmp_path, monkeypatch):
+    path = open4d.save(rich_sequence(), tmp_path / "capture.usdc")
+    calls = []
+    from open4d.io import _usd
+
+    real = _usd.UsdSequenceProvider.get_frame
+    monkeypatch.setattr(
+        _usd.UsdSequenceProvider,
+        "get_frame",
+        lambda self, index: (calls.append(index), real(self, index))[1],
+    )
+
+    decoded = open4d.load(path)
+    assert calls == []
+    assert len(decoded) == 2
+    assert decoded.timestamps == (5.0, 4.0)
+    assert calls == []
+    _ = decoded[1]
+    assert calls == [1]
+    decoded.close()
+
+
+def test_usd_empty_geometry_omits_extent_and_round_trips(tmp_path):
+    empty = TriangleMesh(
+        np.empty((0, 3), dtype=np.float32),
+        np.empty((0, 3), dtype=np.uint32),
+    )
+    source = Sequence(MemoryFrameProvider([Frame(0, 0.0, empty)]))
+
+    decoded = open4d.load(open4d.save(source, tmp_path / "empty.usdc"))
+
+    assert decoded[0].geometry.positions.shape == (0, 3)
+    assert decoded[0].geometry.triangles.shape == (0, 3)
+    decoded.close()
+
+
+def test_usd_write_failure_preserves_an_existing_destination(tmp_path):
+    destination = tmp_path / "capture.usdc"
+    destination.write_bytes(b"keep me")
+    bad = Sequence(MemoryFrameProvider(
+        tuple(rich_sequence()), metadata={"invalid": object()},
+        allow_nonmonotonic_timestamps=True,
+    ))
+
+    with pytest.raises(EncodeError, match="serializable"):
+        open4d.save(bad, destination, overwrite=True)
+
+    assert destination.read_bytes() == b"keep me"
+
+
+def test_module_level_usd_apis_delegate_to_the_public_backend(tmp_path):
+    destination = write_sequence(
+        rich_sequence(), tmp_path / "capture.usdc", options={"up_axis": "z"}
+    )
+
+    decoded = open_sequence(destination)
+
+    assert decoded.metadata["up_axis"] == "z"
+    assert_rich_round_trip(rich_sequence(), decoded)
+    decoded.close()
+
+
+def test_generic_time_sampled_usd_is_a_lazy_sequence_import(tmp_path):
+    from pxr import Usd, UsdGeom, Vt
+
+    path = tmp_path / "third-party.usda"
+    stage = Usd.Stage.CreateNew(str(path))
+    stage.SetTimeCodesPerSecond(24)
+    mesh = UsdGeom.Mesh.Define(stage, "/World/Mesh")
+    mesh.CreateFaceVertexCountsAttr().Set(Vt.IntArray([3]))
+    mesh.CreateFaceVertexIndicesAttr().Set(Vt.IntArray([0, 1, 2]))
+    points = mesh.CreatePointsAttr()
+    points.Set(Vt.Vec3fArray([(0, 0, 0), (1, 0, 0), (0, 1, 0)]), 0)
+    points.Set(Vt.Vec3fArray([(1, 0, 0), (2, 0, 0), (1, 1, 0)]), 1)
+    stage.GetRootLayer().Save()
+
+    sequence = open4d.load(path)
+
+    assert len(sequence) == 2
+    assert sequence.timestamps == (0.0, 1 / 24)
+    np.testing.assert_array_equal(sequence[1].geometry.positions[0], [1, 0, 0])
+    sequence.close()
+
+
+def test_generic_usd_discovers_frames_from_animated_topology(tmp_path):
+    from pxr import Usd, UsdGeom, Vt
+
+    path = tmp_path / "animated-topology.usda"
+    stage = Usd.Stage.CreateNew(str(path))
+    mesh = UsdGeom.Mesh.Define(stage, "/World/Mesh")
+    mesh.CreatePointsAttr().Set(
+        Vt.Vec3fArray([(0, 0, 0), (1, 0, 0), (0, 1, 0)])
+    )
+    counts = mesh.CreateFaceVertexCountsAttr()
+    indices = mesh.CreateFaceVertexIndicesAttr()
+    counts.Set(Vt.IntArray([]), 0)
+    indices.Set(Vt.IntArray([]), 0)
+    counts.Set(Vt.IntArray([3]), 1)
+    indices.Set(Vt.IntArray([0, 1, 2]), 1)
+    stage.GetRootLayer().Save()
+
+    sequence = open4d.load(path)
+
+    assert len(sequence) == 2
+    assert len(sequence[0].geometry.triangles) == 0
+    np.testing.assert_array_equal(sequence[1].geometry.triangles, [[0, 1, 2]])
+    sequence.close()
+
+
+def test_generic_usd_discovers_frames_from_animated_colors(tmp_path):
+    from pxr import Sdf, Usd, UsdGeom, Vt
+
+    path = tmp_path / "animated-colors.usda"
+    stage = Usd.Stage.CreateNew(str(path))
+    points = UsdGeom.Points.Define(stage, "/World/Points")
+    points.CreatePointsAttr().Set(
+        Vt.Vec3fArray([(0, 0, 0), (1, 0, 0), (0, 1, 0)])
+    )
+    colors = UsdGeom.PrimvarsAPI(points.GetPrim()).CreatePrimvar(
+        "displayColor", Sdf.ValueTypeNames.Color3fArray, UsdGeom.Tokens.vertex
+    )
+    colors.Set(Vt.Vec3fArray([(1, 0, 0)] * 3), 0)
+    colors.Set(Vt.Vec3fArray([(0, 1, 0)] * 3), 1)
+    stage.GetRootLayer().Save()
+
+    sequence = open4d.load(path)
+
+    assert len(sequence) == 2
+    np.testing.assert_array_equal(sequence[0].geometry.colors, [[1, 0, 0]] * 3)
+    np.testing.assert_array_equal(sequence[1].geometry.colors, [[0, 1, 0]] * 3)
+    sequence.close()
+
+
+def test_usd_export_clears_standard_optional_attributes_when_absent(tmp_path):
+    from pxr import Usd, UsdGeom
+
+    positions = np.array(
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32
+    )
+    triangles = np.array([[0, 1, 2]], dtype=np.uint32)
+    rgba = np.array(
+        [[1, 0, 0, 0.25], [0, 1, 0, 0.5], [0, 0, 1, 0.75]],
+        dtype=np.float32,
+    )
+    rgb = rgba[:, :3]
+    normals = np.array([[0, 0, 1]] * 3, dtype=np.float32)
+    source = Sequence(MemoryFrameProvider([
+        Frame(0, 0.0, TriangleMesh(
+            positions, triangles, colors=rgba, normals=normals
+        )),
+        Frame(1, 1.0, TriangleMesh(positions, triangles, colors=rgb)),
+        Frame(2, 2.0, TriangleMesh(positions, triangles)),
+    ]))
+
+    path = open4d.save(source, tmp_path / "optional-streams.usda")
+    stage = Usd.Stage.Open(str(path))
+    mesh = UsdGeom.Mesh(stage.GetPrimAtPath("/Open4D/Sequence"))
+    primvars = UsdGeom.PrimvarsAPI(mesh.GetPrim())
+    colors = primvars.GetPrimvar("displayColor")
+    opacity = primvars.GetPrimvar("displayOpacity")
+    exported_normals = mesh.GetNormalsAttr()
+
+    assert len(colors.Get(1)) == 3
+    assert len(opacity.Get(1)) == 0
+    assert len(exported_normals.Get(1)) == 0
+    assert len(colors.Get(2)) == 0
+    assert len(opacity.Get(2)) == 0
+    assert len(exported_normals.Get(2)) == 0
+
+
+def test_reader_accepts_the_prototype_open4d_usd_layout(tmp_path):
+    from pxr import Sdf, Usd, UsdGeom, Vt
+
+    path = tmp_path / "prototype.usda"
+    stage = Usd.Stage.CreateNew(str(path))
+    mesh = UsdGeom.Mesh.Define(stage, "/Open4D/Sequence")
+    mesh.CreateFaceVertexCountsAttr().Set(Vt.IntArray([3]))
+    mesh.CreateFaceVertexIndicesAttr().Set(Vt.IntArray([0, 1, 2]))
+    mesh.CreatePointsAttr().Set(
+        Vt.Vec3fArray([(0, 0, 0), (1, 0, 0), (0, 1, 0)]), 0
+    )
+    prim = mesh.GetPrim()
+    prim.CreateAttribute("open4d:frameIndex", Sdf.ValueTypeNames.Int).Set(17, 0)
+    prim.CreateAttribute("open4d:timestamp", Sdf.ValueTypeNames.Double).Set(2.5, 0)
+    prim.CreateAttribute("open4d:keyFrame", Sdf.ValueTypeNames.Bool).Set(True, 0)
+    stage.GetRootLayer().customLayerData = {
+        "open4d": {
+            "version": 1,
+            "source": "prototype-capture",
+            "key_frame_indices": [0],
+        }
+    }
+    stage.GetRootLayer().Save()
+
+    sequence = open4d.load(path)
+    frame = sequence[0]
+
+    assert sequence.metadata["version"] == 1
+    assert sequence.metadata["source"] == "prototype-capture"
+    assert sequence.metadata["key_frame_indices"] == [0]
+    assert frame.frame_index == 17
+    assert frame.timestamp == 2.5
+    assert frame.metadata["keyFrame"] is True
+    sequence.close()
+
+
+def test_usd_format_is_advertised_as_one_sequence_container_family():
+    usd = next(info for info in available_formats() if info.id == "usd")
+
+    assert usd.suffixes == (".usd", ".usda", ".usdc", ".usdz")
+    assert usd.dependency_extra == "usd"
+
+
+def test_missing_openusd_dependency_has_an_exact_install_hint(monkeypatch):
+    import builtins
+    from open4d.io import _usd
+
+    real_import = builtins.__import__
+
+    def without_pxr(name, *args, **kwargs):
+        if name == "pxr":
+            raise ImportError("not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", without_pxr)
+
+    with pytest.raises(MissingDependencyError, match=r"pip install 'open4d\[usd\]'"):
+        _usd._pxr()

--- a/open4d/io/tests/test_usd_sequence.py
+++ b/open4d/io/tests/test_usd_sequence.py
@@ -143,6 +143,30 @@ def test_usd_empty_geometry_omits_extent_and_round_trips(tmp_path):
     decoded.close()
 
 
+def test_usd_empty_frame_clears_the_previous_extent_sample(tmp_path):
+    from pxr import Usd, UsdGeom
+
+    positions = np.array(
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32
+    )
+    triangles = np.array([[0, 1, 2]], dtype=np.uint32)
+    empty_positions = np.empty((0, 3), dtype=np.float32)
+    empty_triangles = np.empty((0, 3), dtype=np.uint32)
+    source = Sequence(MemoryFrameProvider([
+        Frame(0, 0.0, TriangleMesh(positions, triangles)),
+        Frame(1, 1.0, TriangleMesh(empty_positions, empty_triangles)),
+    ]))
+
+    path = open4d.save(source, tmp_path / "mixed-empty.usda")
+    stage = Usd.Stage.Open(str(path))
+    mesh = UsdGeom.Mesh(stage.GetPrimAtPath("/Open4D/Sequence"))
+    extent = mesh.GetExtentAttr()
+
+    assert extent.GetTimeSamples() == [0.0, 1.0]
+    assert len(extent.Get(0)) == 2
+    assert len(extent.Get(1)) == 0
+
+
 def test_usd_write_failure_preserves_an_existing_destination(tmp_path):
     destination = tmp_path / "capture.usdc"
     destination.write_bytes(b"keep me")

--- a/open4d/visualization/_api.py
+++ b/open4d/visualization/_api.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import math
+import os
 from pathlib import Path
 
 from open4d.core import Sequence
 
-from ._frames import UP_AXES, UP_TO_Z, decode_all
+from ._frames import LazyRenderSequence, UP_AXES, UP_TO_Z
 
 
 @dataclass(frozen=True)
@@ -33,7 +34,12 @@ class ViewerOptions:
 
 
 def _prepare(
-    sequence: Sequence, *, stride: int, fps: float | None, up: str
+    sequence: Sequence,
+    *,
+    stride: int,
+    fps: float | None,
+    up: str | None,
+    cache_size: int,
 ):
     if not isinstance(sequence, Sequence):
         raise TypeError("sequence must be an open4d.Sequence")
@@ -41,12 +47,34 @@ def _prepare(
         raise ValueError("cannot visualize an empty sequence")
     if not isinstance(stride, int) or isinstance(stride, bool) or stride < 1:
         raise ValueError("stride must be a positive integer")
-    if up not in UP_AXES:
+    selected_up = up
+    if selected_up is None:
+        recorded = str(sequence.metadata.get("up_axis", "")).lower()
+        selected_up = recorded if recorded in UP_AXES else "z"
+    if selected_up not in UP_AXES:
         raise ValueError(f"up must be one of {UP_AXES}")
-    playback_fps = float(fps if fps is not None else sequence.fps or 30.0)
+    declared_fps = sequence.metadata.get("fps")
+    playback_fps = float(
+        fps if fps is not None else declared_fps or sequence.fps or 30.0
+    )
     if not math.isfinite(playback_fps) or playback_fps <= 0:
         raise ValueError("fps must be finite and greater than zero")
-    return decode_all(sequence, stride, UP_TO_Z[up]), playback_fps
+    return LazyRenderSequence(
+        sequence,
+        stride=stride,
+        order=UP_TO_Z[selected_up],
+        cache_size=cache_size,
+    ), playback_fps
+
+
+def _open_source(source: Sequence | str | os.PathLike[str]) -> tuple[Sequence, bool]:
+    if isinstance(source, Sequence):
+        return source, False
+    if isinstance(source, (str, os.PathLike)):
+        from open4d import _api as public_api
+
+        return public_api.load(source), True
+    raise TypeError("source must be an open4d.Sequence or path-like sequence source")
 
 
 def _options(fps: float, values: dict) -> ViewerOptions:
@@ -68,31 +96,44 @@ def _options(fps: float, values: dict) -> ViewerOptions:
 
 
 def visualize(
-    sequence: Sequence,
+    source: Sequence | str | os.PathLike[str],
     *,
     stride: int = 1,
     fps: float | None = None,
-    up: str = "z",
+    up: str | None = None,
+    cache_size: int = 3,
     **viewer_options,
 ) -> None:
-    """Open an interactive Qt viewer for a sequence.
+    """Open an interactive Qt viewer for a sequence or sequence file.
 
     PyQt6, pyqtgraph, and PyOpenGL are imported only when this function runs.
     """
     from . import _qt
 
     _qt.check_available()
-    frames, playback_fps = _prepare(sequence, stride=stride, fps=fps, up=up)
-    _qt.play(frames, _options(playback_fps, viewer_options))
+    sequence, owned = _open_source(source)
+    try:
+        frames, playback_fps = _prepare(
+            sequence,
+            stride=stride,
+            fps=fps,
+            up=up,
+            cache_size=cache_size,
+        )
+        _qt.play(frames, _options(playback_fps, viewer_options))
+    finally:
+        if owned:
+            sequence.close()
 
 
 def render_gif(
-    sequence: Sequence,
+    source: Sequence | str | os.PathLike[str],
     output: str | Path,
     *,
     stride: int = 1,
     fps: float | None = None,
-    up: str = "z",
+    up: str | None = None,
+    cache_size: int = 3,
     **viewer_options,
 ) -> Path:
     """Render a sequence to an animated GIF and return its path."""
@@ -102,6 +143,17 @@ def render_gif(
     from . import _qt
 
     _qt.check_available(gif=True)
-    frames, playback_fps = _prepare(sequence, stride=stride, fps=fps, up=up)
-    _qt.record(frames, _options(playback_fps, viewer_options), path)
-    return path
+    sequence, owned = _open_source(source)
+    try:
+        frames, playback_fps = _prepare(
+            sequence,
+            stride=stride,
+            fps=fps,
+            up=up,
+            cache_size=cache_size,
+        )
+        _qt.record(frames, _options(playback_fps, viewer_options), path)
+        return path
+    finally:
+        if owned:
+            sequence.close()

--- a/open4d/visualization/_frames.py
+++ b/open4d/visualization/_frames.py
@@ -15,6 +15,8 @@ rotation, so geometry is reoriented without being mirrored.
 
 from __future__ import annotations
 
+from collections import OrderedDict
+import operator
 from typing import NamedTuple
 
 import numpy as np
@@ -77,6 +79,66 @@ def to_render_frame(frame, order: list[int]) -> RenderFrame:
         frame_index=int(frame.frame_index),
         timestamp=float(frame.timestamp),
     )
+
+
+class LazyRenderSequence:
+    """Strided, bounded LRU view that converts core frames on demand."""
+
+    def __init__(
+        self,
+        sequence,
+        *,
+        stride: int,
+        order: list[int],
+        cache_size: int = 3,
+    ) -> None:
+        if not isinstance(stride, int) or isinstance(stride, bool) or stride < 1:
+            raise ValueError("stride must be a positive integer")
+        if (
+            not isinstance(cache_size, int)
+            or isinstance(cache_size, bool)
+            or cache_size < 1
+        ):
+            raise ValueError("cache_size must be a positive integer")
+        self.sequence = sequence
+        self.indices = range(0, len(sequence), stride)
+        self.order = order
+        self.cache_size = cache_size
+        self._cache: OrderedDict[int, RenderFrame] = OrderedDict()
+
+    def __len__(self) -> int:
+        return len(self.indices)
+
+    @property
+    def cached_indices(self) -> tuple[int, ...]:
+        """Displayed ordinals currently retained by the LRU cache."""
+        return tuple(self._cache)
+
+    def __getitem__(self, index: int) -> RenderFrame:
+        if isinstance(index, bool):
+            raise TypeError("render frame indices must be integers")
+        try:
+            ordinal = operator.index(index)
+        except TypeError as error:
+            raise TypeError("render frame indices must be integers") from error
+        if ordinal < 0:
+            ordinal += len(self)
+        if ordinal < 0 or ordinal >= len(self):
+            raise IndexError("render frame index out of range")
+        cached = self._cache.pop(ordinal, None)
+        if cached is None:
+            cached = to_render_frame(
+                self.sequence[self.indices[ordinal]], self.order
+            )
+        self._cache[ordinal] = cached
+        while len(self._cache) > self.cache_size:
+            self._cache.popitem(last=False)
+        return cached
+
+    def prefetch(self, index: int) -> None:
+        """Decode one valid future frame while retaining the cache bound."""
+        if 0 <= index < len(self) and index not in self._cache:
+            self[index]
 
 
 def decode_all(sequence, stride: int, order: list[int]) -> list[RenderFrame]:

--- a/open4d/visualization/_qt.py
+++ b/open4d/visualization/_qt.py
@@ -62,7 +62,7 @@ def check_available(*, gif: bool = False) -> None:
 class Scene:
     """A GL view holding one sequence, with the frame it shows swappable."""
 
-    def __init__(self, frames: list, args) -> None:
+    def __init__(self, frames, args) -> None:
         QtWidgets, _QtCore, gl = _qt()
         from pyqtgraph import Vector
         from pyqtgraph.opengl import shaders
@@ -85,7 +85,10 @@ class Scene:
             tuple(int(255 * channel) for channel in args.background)
         )
 
-        lower, upper = render_frames.bounds(frames)
+        # Framing from the first displayed frame keeps opening lazy. A complete
+        # sequence-wide bounds scan would decode every frame before playback.
+        first = frames[0]
+        lower, upper = render_frames.bounds([first])
         center = (lower + upper) / 2.0
         span = float(np.max(upper - lower)) or 1.0
         # pyqtgraph keeps the orbit centre in opts and measures distance in world
@@ -99,7 +102,6 @@ class Scene:
 
         # Both item kinds exist from the start and visibility is switched per
         # frame, so a folder mixing meshes and point clouds still draws.
-        first = frames[0]
         self.mesh_item = gl.GLMeshItem(
             meshdata=self._mesh_data(first) if first.is_mesh else gl.MeshData(),
             smooth=False,
@@ -201,7 +203,7 @@ class Scene:
             draw.text((12, 10 + 16 * row), line, fill=(70, 70, 78), font=font)
 
 
-def play(frames: list, args) -> None:
+def play(frames, args) -> None:
     """Open the window and run until it is closed."""
     QtWidgets, QtCore, _gl = _qt()
     scene = Scene(frames, args)
@@ -274,6 +276,10 @@ def play(frames: list, args) -> None:
                 self.slider.blockSignals(True)
                 self.slider.setValue(scene.index)
                 self.slider.blockSignals(False)
+            prefetch = getattr(frames, "prefetch", None)
+            if callable(prefetch):
+                target = (scene.index + 1) % len(frames)
+                QtCore.QTimer.singleShot(0, lambda: prefetch(target))
 
         def advance(self) -> None:
             if self.playing:
@@ -312,7 +318,7 @@ def play(frames: list, args) -> None:
     scene.application.exec()
 
 
-def record(frames: list, args, output: Path) -> None:
+def record(frames, args, output: Path) -> None:
     """Render every frame to an animated GIF, without opening a window."""
     image_module = require("PIL.Image", "player")
     if output.suffix.lower() != ".gif":

--- a/open4d/visualization/tests/test_visualization.py
+++ b/open4d/visualization/tests/test_visualization.py
@@ -11,7 +11,7 @@ from open4d.visualization import (
     render_gif,
     visualize,
 )
-from open4d.visualization._frames import shade
+from open4d.visualization._frames import LazyRenderSequence, shade
 
 pytestmark = pytest.mark.cpu
 
@@ -43,6 +43,38 @@ def test_visualize_prepares_real_frames_without_importing_qt(monkeypatch):
     )
 
 
+def test_lazy_render_sequence_strides_and_evicts_frames():
+    calls = []
+
+    class Provider:
+        frame_count = 6
+
+        def get_frame(self, index):
+            calls.append(index)
+            mesh = TriangleMesh(
+                np.array(
+                    [[index, 0, 0], [index + 1, 0, 0], [index, 1, 0]],
+                    dtype=np.float32,
+                ),
+                [[0, 1, 2]],
+            )
+            return Frame(index, index / 30, mesh)
+
+    frames = LazyRenderSequence(Sequence(Provider()), stride=2, order=[0, 1, 2], cache_size=2)
+
+    assert len(frames) == 3
+    assert calls == []
+    assert frames[0].frame_index == 0
+    assert frames[0].frame_index == 0
+    assert calls == [0]
+    frames.prefetch(1)
+    assert calls == [0, 2]
+    assert frames[2].frame_index == 4
+    assert len(frames.cached_indices) == 2
+    assert frames[0].frame_index == 0
+    assert calls == [0, 2, 4, 0]
+
+
 def test_render_gif_delegates_to_shared_renderer(tmp_path, monkeypatch):
     captured = {}
     from open4d.visualization import _qt
@@ -57,6 +89,77 @@ def test_render_gif_delegates_to_shared_renderer(tmp_path, monkeypatch):
 
     assert output == tmp_path / "preview.gif"
     assert captured == {"output": output, "count": 1}
+
+
+def test_visualize_path_owns_and_closes_loaded_sequence(monkeypatch):
+    value = sequence()
+    close_calls = []
+    real_close = value.close
+    from open4d import _api
+    from open4d.visualization import _qt
+
+    monkeypatch.setattr(
+        _api, "load", lambda source: value
+    )
+    monkeypatch.setattr(_qt, "check_available", lambda **options: None)
+    monkeypatch.setattr(_qt, "play", lambda frames, options: frames[0])
+    monkeypatch.setattr(
+        value, "close", lambda: (close_calls.append(True), real_close())[1]
+    )
+
+    visualize("capture.o4d")
+
+    assert close_calls == [True]
+    assert value.closed is True
+
+
+def test_visualize_does_not_close_a_caller_owned_sequence(monkeypatch):
+    value = sequence()
+    from open4d.visualization import _qt
+
+    monkeypatch.setattr(_qt, "check_available", lambda **options: None)
+    monkeypatch.setattr(_qt, "play", lambda frames, options: frames[0])
+
+    visualize(value)
+
+    assert value.closed is False
+
+
+def test_visualize_path_closes_after_renderer_failure(monkeypatch):
+    value = sequence()
+    from open4d import _api
+    from open4d.visualization import _qt
+
+    monkeypatch.setattr(_api, "load", lambda source: value)
+    monkeypatch.setattr(_qt, "check_available", lambda **options: None)
+    monkeypatch.setattr(
+        _qt, "play", lambda frames, options: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        visualize("capture.o4d")
+
+    assert value.closed is True
+
+
+def test_visualize_uses_sequence_up_axis_by_default(monkeypatch):
+    mesh = TriangleMesh(
+        [[0.0, 0, 0], [1, 0, 0], [0, 2.0, 0]], [[0, 1, 2]]
+    )
+    value = Sequence(MemoryFrameProvider(
+        [Frame(0, 0, mesh)], metadata={"up_axis": "y"}
+    ))
+    captured = {}
+    from open4d.visualization import _qt
+
+    monkeypatch.setattr(_qt, "check_available", lambda **options: None)
+    monkeypatch.setattr(
+        _qt, "play", lambda frames, options: captured.update(frame=frames[0])
+    )
+
+    visualize(value)
+
+    np.testing.assert_array_equal(captured["frame"].positions[2], [0, 0, 2])
 
 
 def test_visualization_arguments_and_shading_are_validated(monkeypatch):
@@ -99,4 +202,23 @@ def test_missing_backend_fails_before_decoding(monkeypatch):
 
     with pytest.raises(VisualizationDependencyError, match="player missing"):
         visualize(value)
+    assert calls == []
+
+
+def test_missing_backend_fails_before_loading_a_path(monkeypatch):
+    from open4d import _api
+    from open4d.visualization import _qt
+
+    calls = []
+    monkeypatch.setattr(_api, "load", lambda source: calls.append(source))
+    monkeypatch.setattr(
+        _qt,
+        "check_available",
+        lambda **options: (_ for _ in ()).throw(
+            VisualizationDependencyError("player missing")
+        ),
+    )
+
+    with pytest.raises(VisualizationDependencyError, match="player missing"):
+        visualize("capture.usdc")
     assert calls == []

--- a/scripts/smoke_installed_io.py
+++ b/scripts/smoke_installed_io.py
@@ -6,6 +6,7 @@ import tempfile
 
 import numpy as np
 
+import open4d
 from open4d.codec import CodecError, available_codecs, decode_sequence, encode_sequence
 from open4d.io import inspect_sequence, open_sequence
 from open4d.visualization import visualize
@@ -18,10 +19,13 @@ with tempfile.TemporaryDirectory() as directory:
     frame = open_sequence(path)[0]
     assert info.frame_count == 1 and info.format == "obj"
     np.testing.assert_array_equal(frame.geometry.triangles, [[0, 1, 2]])
-    artifact = encode_sequence(open_sequence(path), Path(directory) / "triangle.o4d")
-    decoded = decode_sequence(artifact)
+    artifact = open4d.save(open4d.load(path), Path(directory) / "triangle.o4d")
+    decoded = open4d.load(artifact)
     np.testing.assert_array_equal(decoded[0].geometry.positions, frame.geometry.positions)
     assert callable(visualize)
+    assert callable(open4d.visualize)
+    open4d.unload(decoded)
+    assert decoded.closed
     installed = {info.id for info in available_codecs()}
     for codec, suffix in (("temporal-delta", ".td4d"), ("temporal-pca", ".tp4d")):
         temporal_artifact = encode_sequence(
@@ -38,5 +42,4 @@ with tempfile.TemporaryDirectory() as directory:
         assert "source checkout" in str(error)
     else:
         raise AssertionError("source-only KLT was advertised by the installed wheel")
-    decoded.close()
     print(f"loaded and round-tripped {len(frame.geometry.positions)} vertices")


### PR DESCRIPTION
## Summary

- add top-level `open4d.load`, `open4d.save`, and `open4d.unload` sequence entry points
- add lazy OpenUSD sequence-container reading and complete model round trips
- add path-based, bounded-cache visualization while preserving resource lifecycles
- route the visualization examples through the public API and update the documentation
- handle generic USD animation streams, disappearing optional attributes and extents, and concise CLI loader errors
- keep documented frame-directory formats aligned with the public loader

## Not included

Direct import or visualization of a raw V-DMC `.vmesh` bitstream is **not included in this PR**. The existing Open4D `.v4d` wrapper remains supported because it carries the codec identity, frame metadata, position bounds, and optional decoder configuration needed to decode and visualize the embedded V-DMC stream. Raw `.vmesh` support will be handled separately.

## Testing

- `python3 -m pytest -q` — 311 passed, 26 dependency/hardware-gated skips
- mixed non-empty/empty USD extent regression passed
- generic USD animation and disappearing-attribute regressions passed
- wheel build and installed-package smoke test passed
- `git diff --check` passed