### PR TITLE
Add raw V-DMC .vmesh visualization

### DIFF
--- a/examples/visualization/README.md
+++ b/examples/visualization/README.md
@@ -110,12 +110,28 @@ one and say so.
 | Folder of `.obj` or `.ply` frames | nothing |
 | Folder of `.stl` `.off` `.glb` `.gltf` frames | `.[tools]` |
 | One USD file (`.usd` `.usda` `.usdc` `.usdz`) | `.[usd]` |
+| Raw MPEG V-DMC bitstream (`.vmesh`) | a compatible native V-DMC decoder |
 | One mesh file | as above |
 
 Frames are ordered by **the last number in the filename**, so `frame_2.obj` comes
 before `frame_10.obj` — but `frame_003_qp9.obj` sorts on 9, not 3. A codec that
 puts a parameter last will silently misalign every frame and look far worse than
 it is; rename before comparing. A frame with no faces is drawn as a point cloud.
+
+### Raw V-DMC bitstreams
+
+Raw `.vmesh` input needs a compatible native decoder:
+
+```bash
+export OPEN4D_VDMC_DECODER=/path/to/vmesh-decoder
+export OPEN4D_VDMC_DECODER_CONFIG=/path/to/decoder.cfg  # optional
+python examples/visualization/visualize_sequence.py capture.vmesh --info
+```
+
+This path is read-only and geometry-only. It defaults to 30 fps, accepts
+`--fps N`, and displays the coordinates emitted by the decoder. Open4D removes
+the temporary decoded OBJ files when the sequence closes. Use `.v4d` when the
+sequence also needs Open4D timestamps, metadata, and coordinate bounds.
 
 ## Flags
 

--- a/examples/visualization/_common.py
+++ b/examples/visualization/_common.py
@@ -41,6 +41,6 @@ def existing_source(path: Path) -> Path:
         return path
     sys.exit(
         f"{path} does not exist.\n"
-        "Pass a folder holding one mesh file per frame, or a USD container.\n"
+        "Pass a sequence file, a frame directory, or a standalone mesh.\n"
         "Run with --help to see every format."
     )

--- a/examples/visualization/compare_sequences.py
+++ b/examples/visualization/compare_sequences.py
@@ -7,7 +7,8 @@
 
 This is the comparison viewer; `visualize_sequence.py` is the plain one. Both
 read the same sources — `.o4d` codec artifacts, time-sampled USD files, frame
-directories, or standalone mesh imports — through the same loader.
+directories, raw V-DMC `.vmesh` bitstreams, or standalone mesh imports —
+through the same loader.
 
 Two synchronized panes: the reference as geometry, the decoded mesh coloured by
 its distance to that reference. One camera drives both, because comparing two
@@ -35,6 +36,8 @@ from pathlib import Path
 from _common import existing_source
 import compare_frames
 from frame_sources import DEFAULT_FPS, describe_source, open_sequence, supported_formats
+from open4d.codec import CodecError
+from open4d.io import Open4DError
 from open4d.visualization._frames import UP_AXES, UP_TO_Z
 
 CSV_COLUMNS = (
@@ -80,7 +83,7 @@ def report_sources(reference, decoded, reference_path, decoded_path, fps) -> Non
         ("decoded", decoded, decoded_path),
     ):
         print(f"\n{label}: {path}")
-        print(f"  {describe_source(path)}")
+        print(f"  {describe_source(path, len(sequence))}")
         print(f"  frames     : {len(sequence)}")
         print(f"  topology   : {sequence.topology.value}")
     print(f"\nplaying at   : {fps:.2f} fps")
@@ -339,7 +342,7 @@ def run(args) -> int:
                 progress=progress,
             )
             print()
-    except (ValueError, TypeError, OSError) as error:
+    except (Open4DError, CodecError, ValueError, TypeError, OSError) as error:
         raise SystemExit(f"\nfailed to compare the sequences:\n  {error}") from None
 
     report_error(comparison)

--- a/examples/visualization/frame_sources.py
+++ b/examples/visualization/frame_sources.py
@@ -10,6 +10,7 @@ from open4d.io import available_formats, inspect_sequence
 
 DEFAULT_FPS = 30.0
 _USD_SUFFIXES = {".usd", ".usda", ".usdc", ".usdz"}
+_RAW_CODEC_SUFFIXES = {".vmesh"}
 _CODEC_SUFFIXES = {
     suffix for info in available_codecs() for suffix in info.suffixes
 }
@@ -28,6 +29,7 @@ def supported_formats() -> str:
         target = sequence_lines if info.id == "usd" else frame_lines
         target.append(f"  {'/'.join(info.suffixes):<24}{extra}".rstrip())
     sequence_lines.append("  codec artifacts such as .o4d, .d4d, and .v4d")
+    sequence_lines.append("  .vmesh                  needs a native V-DMC decoder")
     return "\n".join((*sequence_lines, *frame_lines))
 
 
@@ -38,7 +40,9 @@ def source_kind(path: Path | str) -> str:
         return "folder"
     if not path.exists():
         raise SystemExit(f"{path} does not exist")
-    if path.suffix.lower() in _USD_SUFFIXES | _CODEC_SUFFIXES:
+    if path.suffix.lower() in (
+        _USD_SUFFIXES | _CODEC_SUFFIXES | _RAW_CODEC_SUFFIXES
+    ):
         return "sequence-file"
     try:
         inspect_sequence(path)
@@ -48,18 +52,27 @@ def source_kind(path: Path | str) -> str:
 
 
 def open_sequence(path: Path | str, fps: float | None = None):
-    """Load a source, using ``fps`` only to timestamp frame directories."""
+    """Load a source, using ``fps`` for manifest-free frame timing."""
     path = Path(path)
-    return _open_sequence(path, fps=fps if path.is_dir() else None)
+    uses_import_fps = path.is_dir() or path.suffix.lower() in _RAW_CODEC_SUFFIXES
+    return _open_sequence(path, fps=fps if uses_import_fps else None)
 
 
-def describe_source(path: Path | str) -> str:
-    """Describe a source through public inspection without geometry decoding."""
+def describe_source(path: Path | str, frame_count: int | None = None) -> str:
+    """Describe a source without eagerly parsing its frame geometry."""
     path = Path(path)
-    if path.suffix.lower() in _CODEC_SUFFIXES and path.is_file():
-        with _open_sequence(path) as sequence:
+    if (
+        path.suffix.lower() in _CODEC_SUFFIXES | _RAW_CODEC_SUFFIXES
+        and path.is_file()
+    ):
+        if frame_count is not None:
             return (
-                f"sequence file: {path.suffix.lower()} ({len(sequence)} frames), "
+                f"sequence file: {path.suffix.lower()} ({frame_count} frames), "
+                f"{path.stat().st_size / 1e6:.2f} MB on disk"
+            )
+        with _open_sequence(path) as opened:
+            return (
+                f"sequence file: {path.suffix.lower()} ({len(opened)} frames), "
                 f"{path.stat().st_size / 1e6:.2f} MB on disk"
             )
     info = inspect_sequence(path)

--- a/examples/visualization/tests/test_frame_sources.py
+++ b/examples/visualization/tests/test_frame_sources.py
@@ -43,3 +43,26 @@ def test_documentation_does_not_advertise_usd_frame_directories():
     )
 
     assert "Folder of `.usd` frames" not in readme
+
+
+def test_example_helpers_advertise_raw_vdmc_as_a_sequence_source(tmp_path):
+    bitstream = tmp_path / "capture.vmesh"
+    bitstream.write_bytes(b"raw bitstream")
+
+    assert frame_sources.source_kind(bitstream) == "sequence-file"
+    assert ".vmesh" in frame_sources.supported_formats()
+
+
+def test_raw_vmesh_fps_is_forwarded_to_the_public_loader(tmp_path, monkeypatch):
+    bitstream = tmp_path / "capture.vmesh"
+    bitstream.write_bytes(b"raw bitstream")
+    received = {}
+    monkeypatch.setattr(
+        frame_sources,
+        "_open_sequence",
+        lambda path, **options: received.update(path=path, **options),
+    )
+
+    frame_sources.open_sequence(bitstream, fps=24)
+
+    assert received == {"path": bitstream, "fps": 24}

--- a/examples/visualization/tests/test_visualize_sequence.py
+++ b/examples/visualization/tests/test_visualize_sequence.py
@@ -66,7 +66,9 @@ def test_single_sequence_cli_reaches_playback_without_eager_decoding(
     path.touch()
     captured = {}
     monkeypatch.setattr(cli, "open_sequence", lambda *args, **kwargs: sequence)
-    monkeypatch.setattr(cli, "describe_source", lambda path: "test sequence")
+    monkeypatch.setattr(
+        cli, "describe_source", lambda path, frame_count=None: "test sequence"
+    )
     monkeypatch.setattr(sys, "argv", ["visualize_sequence.py", str(path)])
     from open4d.visualization import _qt
 

--- a/examples/visualization/visualize_sequence.py
+++ b/examples/visualization/visualize_sequence.py
@@ -6,13 +6,14 @@
     python examples/visualization/visualize_sequence.py my_capture.usdc
 
 Point it at your own data. A source is normally a whole-sequence file such as
-`.o4d` or a time-sampled `.usdc`. A folder holding one mesh per frame and a
-standalone mesh remain useful import paths. Meshes and point clouds are both
-handled: a frame with no faces is drawn as a point cloud.
+`.o4d`, a time-sampled `.usdc`, or a raw V-DMC `.vmesh` bitstream. A folder
+holding one mesh per frame and a standalone mesh remain useful import paths.
+Meshes and point clouds are both handled: a frame with no faces is drawn as a
+point cloud.
 
 Start with `--info`. It reports frame count, timing, and topology without
-decoding geometry or opening a window, which is the quickest way to see whether
-a dataset loads and what the loader made of it.
+parsing frame geometry or opening a window, which is the quickest way to see
+whether a dataset loads and what the loader made of it.
 
 In the window: drag to orbit, scroll to zoom, drag the slider to scrub, space to
 pause, left/right to step, q to quit. Frame number, timestamp and vertex/triangle
@@ -37,9 +38,10 @@ from _common import existing_source
 from frame_sources import (
     DEFAULT_FPS,
     describe_source,
+    open_sequence,
     supported_formats,
 )
-from open4d import load as open_sequence, save as save_sequence
+from open4d import save as save_sequence
 from open4d.codec import CodecError
 from open4d.io import Open4DError
 from open4d.visualization._frames import (
@@ -57,7 +59,7 @@ PLOT_UP = 2
 def report(sequence, path: Path, fps: float) -> None:
     """Print what the sequence declares, before decoding any geometry."""
     print(f"\n{path}")
-    print(f"  {describe_source(path)}")
+    print(f"  {describe_source(path, len(sequence))}")
     print(f"  frames     : {len(sequence)}")
     print(f"  duration   : {sequence.duration:.3f} s at "
           f"{sequence.fps or 0:.2f} fps")
@@ -130,8 +132,8 @@ def main() -> None:
         "path",
         type=Path,
         nargs="?",
-        help="your sequence: an .o4d or USD file, a frame directory, or a "
-        "standalone mesh import",
+        help="your sequence: an .o4d, USD, or raw .vmesh file; a frame "
+        "directory; or a standalone mesh import",
     )
     parser.add_argument(
         "--stride", type=int, default=1, help="keep every Nth frame"
@@ -140,8 +142,8 @@ def main() -> None:
         "--fps",
         type=float,
         default=None,
-        help="override playback; for a manifest-free frame directory this also "
-        "defines imported timestamps (default: 30 fps)",
+        help="override playback; for a manifest-free frame directory or raw "
+        ".vmesh this also defines imported timestamps (default: 30 fps)",
     )
     parser.add_argument(
         "--up",
@@ -224,8 +226,7 @@ def main() -> None:
     # A malformed frame in someone else's dataset is ordinary, not a crash, so
     # report it as an error naming the file rather than a traceback.
     try:
-        import_fps = args.fps if path.is_dir() else None
-        with open_sequence(path, fps=import_fps) as sequence:
+        with open_sequence(path, fps=args.fps) as sequence:
             # One rate, resolved once, used for reporting, playback, GIF timing
             # and any container we write.
             fps = resolve_fps(sequence, args.fps)

--- a/open4d/_api.py
+++ b/open4d/_api.py
@@ -11,6 +11,7 @@ from .core import Sequence
 from .io import open_sequence, write_sequence
 
 _USD_SUFFIXES = frozenset((".usd", ".usda", ".usdc", ".usdz"))
+_RAW_VMESH_SUFFIX = ".vmesh"
 
 
 def _options(value: Mapping[str, object] | None) -> dict[str, object]:
@@ -29,6 +30,14 @@ def _codec_suffixes() -> dict[str, list[str]]:
     return suffixes
 
 
+def _set_raw_fps(options: dict[str, object], fps: float | None) -> None:
+    if fps is None:
+        return
+    if "fps" in options:
+        raise TypeError("fps was passed both by name and in options")
+    options["fps"] = fps
+
+
 def load(
     source: str | os.PathLike[str],
     *,
@@ -37,15 +46,21 @@ def load(
     fps: float | None = None,
     options: Mapping[str, object] | None = None,
 ) -> Sequence:
-    """Open a complete sequence artifact or an importable geometry source."""
+    """Open a sequence artifact, raw V-DMC bitstream, or geometry source."""
     if format is not None and codec is not None:
         raise TypeError("format and codec are mutually exclusive")
     values = _options(options)
     path = Path(source)
     if codec is not None:
-        if fps is not None:
+        if fps is not None and path.suffix.lower() != _RAW_VMESH_SUFFIX:
             raise TypeError("fps applies to I/O sources, not codec artifacts")
+        _set_raw_fps(values, fps)
         return decode_sequence(path, codec=codec, **values)
+    if not path.is_dir() and path.suffix.lower() == _RAW_VMESH_SUFFIX:
+        if format is not None:
+            raise TypeError("format cannot select a raw V-DMC bitstream")
+        _set_raw_fps(values, fps)
+        return decode_sequence(path, codec="vdmc", **values)
     if not path.is_dir() and path.suffix.lower() in _codec_suffixes():
         if format is not None:
             raise TypeError("format cannot select a codec artifact")

--- a/open4d/codec/_vmesh.py
+++ b/open4d/codec/_vmesh.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import json
+import math
+from numbers import Real
 import os
 from pathlib import Path
 import subprocess
@@ -14,7 +16,7 @@ from zipfile import BadZipFile, ZIP_STORED, ZipFile
 import numpy as np
 
 from open4d.core import Frame, Sequence, TopologyMode, TriangleMesh
-from open4d.io import open_sequence
+from open4d.io import Open4DError, open_sequence
 from open4d.io._mesh import write_obj
 
 from ._npz import _json_value
@@ -22,6 +24,7 @@ from ._protocol import CodecError
 
 _SCHEMA = "open4d.vmesh-sequence/v1"
 _POSITION_BIT_DEPTH = 12
+_DEFAULT_RAW_FPS = 30.0
 
 
 def _executable(value: str | os.PathLike[str] | None, variable: str) -> Path:
@@ -32,6 +35,29 @@ def _executable(value: str | os.PathLike[str] | None, variable: str) -> Path:
     if not path.is_file() or not os.access(path, os.X_OK):
         raise CodecError(f"native codec executable is not runnable: {path}")
     return path
+
+
+def _configuration(
+    value: str | os.PathLike[str] | None, variable: str
+) -> Path | None:
+    selected = value or os.environ.get(variable)
+    if not selected:
+        return None
+    path = Path(selected).absolute()
+    if not path.is_file():
+        raise CodecError(f"native codec configuration is missing: {path}")
+    return path
+
+
+def _raw_fps(value: float | None) -> float:
+    if value is None:
+        return _DEFAULT_RAW_FPS
+    if not isinstance(value, Real) or isinstance(value, bool):
+        raise TypeError("fps must be a real number or None")
+    result = float(value)
+    if not math.isfinite(result) or result <= 0:
+        raise ValueError("fps must be finite and greater than zero")
+    return result
 
 
 def _run(command: list[str], label: str) -> None:
@@ -81,6 +107,47 @@ class _DecodedProvider:
             record["frame_index"], record["timestamp"], geometry,
             record.get("metadata", {}),
         )
+
+    def close(self) -> None:
+        self.decoded.close()
+        self.temporary.cleanup()
+
+
+class _RawDecodedProvider:
+    def __init__(
+        self,
+        temporary: tempfile.TemporaryDirectory,
+        decoded: Sequence,
+        source: Path,
+        codec: str,
+        fps: float,
+    ) -> None:
+        self.temporary = temporary
+        self.decoded = decoded
+        self.metadata = MappingProxyType(
+            {
+                "name": source.stem,
+                "source": str(source),
+                "format": ".vmesh",
+                "codec": codec,
+                "fps": fps,
+                "raw_bitstream": True,
+            }
+        )
+        self.topology = decoded.topology
+        self.has_constant_vertex_count = decoded.has_constant_vertex_count
+        self.has_vertex_correspondence = decoded.has_vertex_correspondence
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.decoded)
+
+    @property
+    def timestamps(self) -> tuple[float, ...]:
+        return self.decoded.timestamps
+
+    def get_frame(self, index: int) -> Frame:
+        return self.decoded[index]
 
     def close(self) -> None:
         self.decoded.close()
@@ -199,35 +266,76 @@ class VMeshCodec:
         return destination
 
     def decode(
-        self, source: Path, *, decoder: str | os.PathLike[str] | None = None
+        self,
+        source: Path,
+        *,
+        decoder: str | os.PathLike[str] | None = None,
+        decoder_config: str | os.PathLike[str] | None = None,
+        fps: float | None = None,
     ) -> Sequence:
-        executable = _executable(decoder, f"OPEN4D_{self._environment}_DECODER")
         source = Path(source).absolute()
+        raw = source.suffix.lower() == ".vmesh"
+        if not raw and fps is not None:
+            raise TypeError("fps applies only to manifest-free .vmesh bitstreams")
+        raw_rate = _raw_fps(fps) if raw else None
+        executable = _executable(decoder, f"OPEN4D_{self._environment}_DECODER")
+        config_variable = f"OPEN4D_{self._environment}_DECODER_CONFIG"
+        configured = (
+            _configuration(decoder_config, config_variable)
+            if decoder_config is not None
+            else None
+        )
         temporary = tempfile.TemporaryDirectory(prefix=f"open4d-{self.id}-decode-")
         work = Path(temporary.name)
         try:
-            with ZipFile(source) as archive:
-                manifest = json.loads(archive.read("manifest.json"))
-                if not isinstance(manifest, Mapping):
-                    raise CodecError("V-Mesh artifact manifest root must be an object")
-                if manifest.get("schema") != _SCHEMA or manifest.get("codec") != self.id:
-                    raise CodecError(f"artifact is not {self.id}")
-                archive.extract("sequence.vmesh", work)
-                if "decoder.cfg" in archive.namelist():
-                    archive.extract("decoder.cfg", work)
+            if raw:
+                stream = source
+                manifest = None
+            else:
+                with ZipFile(source) as archive:
+                    manifest = json.loads(archive.read("manifest.json"))
+                    if not isinstance(manifest, Mapping):
+                        raise CodecError("V-Mesh artifact manifest root must be an object")
+                    if (
+                        manifest.get("schema") != _SCHEMA
+                        or manifest.get("codec") != self.id
+                    ):
+                        raise CodecError(f"artifact is not {self.id}")
+                    archive.extract("sequence.vmesh", work)
+                    if "decoder.cfg" in archive.namelist():
+                        archive.extract("decoder.cfg", work)
+                stream = work / "sequence.vmesh"
             output = work / "decoded"
             output.mkdir()
             # The pinned V-DMC decoder parses decTex even with zero attributes.
             command = [str(executable)]
-            if (work / "decoder.cfg").is_file():
-                command.append(f"--config={work / 'decoder.cfg'}")
+            embedded_config = work / "decoder.cfg"
+            config = configured or (
+                embedded_config
+                if embedded_config.is_file()
+                else _configuration(None, config_variable)
+            )
+            if config is not None:
+                command.append(f"--config={config}")
             command.extend([
-                f"--compressed={work / 'sequence.vmesh'}",
+                f"--compressed={stream}",
                 f"--decMesh={output / 'frame_%06d.obj'}",
                 f"--decTex={output / 'texture_%06d.png'}", "--startFrameIndex=0",
             ])
             _run(command, f"{self.id} decoder")
-            decoded = open_sequence(output)
+            try:
+                decoded = open_sequence(output, fps=raw_rate)
+            except (Open4DError, OSError) as error:
+                raise CodecError(
+                    f"{self.id} decoder produced no readable OBJ frames: {error}"
+                ) from error
+            if raw:
+                return Sequence(
+                    _RawDecodedProvider(
+                        temporary, decoded, source, self.id, raw_rate
+                    )
+                )
+            assert manifest is not None
             if len(decoded) != len(manifest["frames"]):
                 raise CodecError(
                     f"{self.id} decoded {len(decoded)} frames, expected {len(manifest['frames'])}"

--- a/open4d/codec/tests/test_codec.py
+++ b/open4d/codec/tests/test_codec.py
@@ -386,6 +386,57 @@ def test_vmesh_uses_one_native_call_per_sequence_direction(tmp_path, monkeypatch
     decoded.close()
 
 
+def test_vmesh_decodes_a_raw_bitstream_without_an_open4d_manifest(
+    tmp_path, monkeypatch
+):
+    import open4d.codec._vmesh as implementation
+
+    executable = tmp_path / "decoder"
+    executable.write_text("native test double", encoding="ascii")
+    executable.chmod(0o700)
+    config = tmp_path / "decoder.cfg"
+    config.write_text("test config", encoding="ascii")
+    bitstream = tmp_path / "capture.vmesh"
+    bitstream.write_bytes(b"raw-vdmc-bitstream")
+    calls = []
+    monkeypatch.setenv("OPEN4D_VDMC_DECODER_CONFIG", str(config))
+
+    def native_call(command, label):
+        calls.append((command, label))
+        options = dict(item[2:].split("=", 1) for item in command[1:] if "=" in item)
+        assert Path(options["compressed"]) == bitstream.absolute()
+        output = Path(options["decMesh"]).parent
+        (output / "frame_000000.obj").write_text(
+            "v 10 20 30\nv 11 20 30\nv 10 21 30\nf 1 2 3\n", encoding="ascii"
+        )
+        (output / "frame_000001.obj").write_text(
+            "v 12 20 30\nv 13 20 30\nv 12 21 30\nf 1 2 3\n", encoding="ascii"
+        )
+
+    monkeypatch.setattr(implementation, "_run", native_call)
+    decoded = VMeshCodec("vdmc").decode(
+        bitstream, decoder=executable, fps=24
+    )
+    decoded_directory = Path(
+        next(item for item in calls[0][0] if item.startswith("--decMesh="))
+        .split("=", 1)[1]
+    ).parent
+
+    assert len(decoded) == 2
+    assert decoded.timestamps == (0.0, 1 / 24)
+    assert decoded.metadata["format"] == ".vmesh"
+    assert decoded.metadata["codec"] == "vdmc"
+    assert decoded.metadata["raw_bitstream"] is True
+    assert decoded[1].frame_index == 1
+    np.testing.assert_array_equal(decoded[0].geometry.positions[0], [10, 20, 30])
+    assert calls[0][1] == "vdmc decoder"
+    assert f"--config={config.absolute()}" in calls[0][0]
+    assert decoded_directory.is_dir()
+
+    decoded.close()
+    assert not decoded_directory.exists()
+
+
 def test_klt_artifact_fresh_decode_uses_saved_payload(tmp_path, monkeypatch):
     import open4d.codec._klt as implementation
 

--- a/open4d/io/tests/test_unified_api.py
+++ b/open4d/io/tests/test_unified_api.py
@@ -57,7 +57,35 @@ def test_top_level_load_rejects_conflicting_dispatch_overrides(tmp_path):
         open4d.load(path, format="obj", codec="npz")
 
 
-@pytest.mark.parametrize("name", ("capture", "frame.obj", "capture.unknown"))
+def test_top_level_load_dispatches_raw_vmesh_to_the_read_only_vdmc_decoder(
+    tmp_path, monkeypatch
+):
+    import open4d._api as implementation
+
+    path = tmp_path / "capture.vmesh"
+    path.write_bytes(b"raw bitstream")
+    expected = sequence()
+    received = {}
+
+    def decode(source, *, codec=None, **options):
+        received.update(source=source, codec=codec, options=options)
+        return expected
+
+    monkeypatch.setattr(implementation, "decode_sequence", decode)
+
+    assert open4d.load(
+        path, fps=24, options={"decoder": "/native/decoder"}
+    ) is expected
+    assert received == {
+        "source": path,
+        "codec": "vdmc",
+        "options": {"decoder": "/native/decoder", "fps": 24},
+    }
+
+
+@pytest.mark.parametrize(
+    "name", ("capture", "frame.obj", "capture.unknown", "capture.vmesh")
+)
 def test_top_level_save_requires_a_sequence_file_extension(tmp_path, name):
     with pytest.raises(ValueError, match="sequence-file extension"):
         open4d.save(sequence(), tmp_path / name)


### PR DESCRIPTION
## What changed

- load raw .vmesh files through the existing native V-DMC decoder adapter
- discover decoded OBJ frames and keep frame parsing bounded and lazy
- support 30 fps default timing with fps overrides
- recognize .vmesh in the visualization and comparison CLIs
- clean temporary decoder output when the sequence closes

Raw .vmesh remains read-only and geometry-only. OPEN4D_VDMC_DECODER selects the decoder; OPEN4D_VDMC_DECODER_CONFIG is optional. Self-describing V-DMC output remains .v4d.

## Verification

- PYTHONPATH=. pytest -q — 316 passed, 26 skipped
- I/O and codec benchmark smoke commands passed
- git diff --check passed

This supersedes #43, which was merged into the old feature branch after #42 had already merged into main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open4dfoundation/codesmith/Open4D/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790796162&installation_model_id=432509&pr_number=47&repository=open4dfoundation%2FOpen4D&return_to=https%3A%2F%2Fgithub.com%2Fopen4dfoundation%2FOpen4D%2Fpull%2F47&signature=c1a9fd998a6d02dda1dabd027ff0645a7e6183824a7dcbea821c556349736d7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->